### PR TITLE
fix: crossOrigin use-credentials is missing from entry module script

### DIFF
--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -83,6 +83,7 @@ export default defineEventHandler((event) => {
       // Load entry module
       const entry = document.createElement('script');
       entry.type = 'module';
+      entry.crossOrigin = 'use-credentials';
       entry.src = '${entryPathValue}';
       document.head.appendChild(entry);
     }


### PR DESCRIPTION
## Summary
- Sets `crossOrigin = 'use-credentials'` on the dynamically created entry module `<script>` tag in app-loader.js
- This ensures basic auth credentials are sent with the cross-origin ES module import request, which is needed when the frontend is protected by basic auth (e.g. via Traefik)

## Test plan
- [ ] Component preview works behind basic auth — entry module loads successfully
- [ ] Component preview continues to work without basic auth (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)