### PR TITLE
fix: Filter out onVue: lifecycle hook props from component schema

### DIFF
--- a/playground/components/global/TestButton.vue
+++ b/playground/components/global/TestButton.vue
@@ -10,6 +10,8 @@
 </template>
 
 <script setup lang="ts">
+import { onMounted } from 'vue'
+
 withDefaults(defineProps<{
   /**
    * Button label text
@@ -40,6 +42,9 @@ withDefaults(defineProps<{
   size: 'medium',
   disabled: false,
 })
+
+// Lifecycle hook for testing that onVue:* props are filtered from schema.
+onMounted(() => {})
 
 const emit = defineEmits(['click'])
 

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -729,6 +729,7 @@ export function generateComponentIndex(
       const vueInternalProps = ['key', 'ref', 'ref_for', 'ref_key', 'class', 'style']
       const props = meta.props
         .filter(p => !vueInternalProps.includes(p.name))
+        .filter(p => !p.name.startsWith('onVue:'))
         .reduce((acc, prop) => {
           // Check for array types first (string[], number[], CanvasImage[], etc.)
           const arrayInfo = detectArrayFromSchema(prop.schema as string | VueMetaSchema | undefined, prop.type)

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -1030,4 +1030,29 @@ describe('Component Index - Prop Metadata Extraction', () => {
       expect(imagesProp.maxItems).toBe(20)
     }, 10000)
   })
+
+  describe('Vue Internal Prop Filtering', () => {
+    it('filters out onVue: lifecycle hook props', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [{
+        pascalName: 'TestButton',
+        kebabName: 'test-button',
+        filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+        shortPath: 'components/global/TestButton.vue',
+        global: true,
+      }]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        { category: 'Test', status: 'stable' },
+      )
+
+      const propNames = Object.keys(result.components[0].props.properties)
+      const vueLifecycleProps = propNames.filter(name => name.startsWith('onVue:'))
+      expect(vueLifecycleProps).toEqual([])
+    }, 10000)
+  })
 })


### PR DESCRIPTION
## Summary
- Filter out `onVue:*` lifecycle hook props (e.g. `onVue:beforeMount`, `onVue:mounted`, `onVue:updated`) from component schema output
- These are internal Vue handlers exposed by `vue-component-meta`, not actual component props
- Add `onMounted` lifecycle hook to TestButton playground component to ensure the filter is exercised
- Add test asserting no `onVue:*` props appear in schema output

## Test plan
- [x] All 64 unit tests pass
- [x] Lint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)