### PR TITLE
fix: remove crossOrigin use-credentials from entry script

### DIFF
--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -83,7 +83,6 @@ export default defineEventHandler((event) => {
       // Load entry module
       const entry = document.createElement('script');
       entry.type = 'module';
-      entry.crossOrigin = 'use-credentials';
       entry.src = '${entryPathValue}';
       document.head.appendChild(entry);
     }


### PR DESCRIPTION
## Problem

#91 added the use-credentials attribute to help with htaccess protected frontends. However, this:
- a) did not fully work since vite is not using this for module-loading and that's not configurable
- b) causes CORS issues now in firefox when other follow-up assets like entry.js lake use-credentials

Thus, we need to revert this.


