### PR TITLE
perf: avoid bundling vue-component-meta and TypeScript in production

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -179,26 +179,44 @@ export default defineNuxtModule<ModuleOptions>({
         }))
       })
 
-      // The server handler reads the config file and generates the component
-      // index. In dev mode this runs on each request (live regeneration).
-      // In production, it is only invoked once during prerendering — the
-      // prerendered static file is then served directly by Nitro.
       nuxt.hook('nitro:config', (nitroConfig) => {
         nitroConfig.virtual = nitroConfig.virtual || {}
         nitroConfig.virtual['#nuxt-component-preview-config-path'] = () => {
           return `export default ${JSON.stringify(configPath)}`
         }
-        // Prerender component-index.json so it is served as a static file
-        // in production (both SSR and SSG builds).
-        nitroConfig.prerender = nitroConfig.prerender || {}
-        nitroConfig.prerender.routes = nitroConfig.prerender.routes || []
-        nitroConfig.prerender.routes.push('/nuxt-component-preview/component-index.json')
       })
 
-      addServerHandler({
-        route: '/nuxt-component-preview/component-index.json',
-        handler: resolver.resolve('./runtime/server/routes/nuxt-component-preview/component-index.json.get'),
-      })
+      if (nuxt.options.dev || nuxt.options._generate) {
+        // Dev: handler for live generation on each request.
+        // SSG (nuxt generate): handler needed for prerendering.
+        addServerHandler({
+          route: '/nuxt-component-preview/component-index.json',
+          handler: resolver.resolve('./runtime/server/routes/nuxt-component-preview/component-index.json.get'),
+        })
+
+        if (nuxt.options._generate) {
+          nuxt.hook('nitro:config', (nitroConfig) => {
+            nitroConfig.prerender = nitroConfig.prerender || {}
+            nitroConfig.prerender.routes = nitroConfig.prerender.routes || []
+            nitroConfig.prerender.routes.push('/nuxt-component-preview/component-index.json')
+          })
+        }
+      }
+      else {
+        // SSR production: generate the component-index at build time and
+        // write it as a static file. No handler registered, so
+        // vue-component-meta and TypeScript (~9MB) stay out of the bundle.
+        nuxt.hook('nitro:build:public-assets', async (nitro) => {
+          const { prepareComponentIndex } = await import('./runtime/server/utils/prepareComponentIndex')
+          const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+          const indexData = prepareComponentIndex(config)
+          if (indexData) {
+            const outputDir = resolve(nitro.options.output.publicDir, 'nuxt-component-preview')
+            fs.mkdirSync(outputDir, { recursive: true })
+            fs.writeFileSync(resolve(outputDir, 'component-index.json'), JSON.stringify(indexData))
+          }
+        })
+      }
     }
   },
 })

--- a/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
+++ b/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
@@ -7,11 +7,20 @@ import configPath from '#nuxt-component-preview-config-path'
  * Serves the component index JSON.
  *
  * Reads the config file written by the module's app:templatesGenerated hook
- * and generates the component index via vue-component-meta. In dev mode this
- * runs on each request so changes are reflected immediately. In production,
- * this handler is only invoked once during prerendering.
+ * and generates the component index via vue-component-meta. In dev mode and
+ * during prerendering this runs the full generation. In production SSR, the
+ * prerendered static file is served by nitro directly — this handler is only
+ * a fallback that returns 404, avoiding bundling vue-component-meta and the
+ * TypeScript compiler (~8.7 MB) into the production server.
  */
 export default defineEventHandler(async (event) => {
+  if (!import.meta.dev && !import.meta.prerender) {
+    throw createError({
+      statusCode: 404,
+      message: 'Component index is only available as a prerendered static asset.',
+    })
+  }
+
   const config = JSON.parse(readFileSync(configPath, 'utf-8'))
   const { prepareComponentIndex } = await import('../../utils/prepareComponentIndex')
   const componentIndexData = prepareComponentIndex(config)

--- a/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
+++ b/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
@@ -7,20 +7,14 @@ import configPath from '#nuxt-component-preview-config-path'
  * Serves the component index JSON.
  *
  * Reads the config file written by the module's app:templatesGenerated hook
- * and generates the component index via vue-component-meta. In dev mode and
- * during prerendering this runs the full generation. In production SSR, the
- * prerendered static file is served by nitro directly — this handler is only
- * a fallback that returns 404, avoiding bundling vue-component-meta and the
- * TypeScript compiler (~8.7 MB) into the production server.
+ * and generates the component index via vue-component-meta.
+ *
+ * This handler is only registered for dev mode (live reload) and SSG
+ * (prerendering). For SSR production builds, the component-index is
+ * generated at build time via a Nuxt hook instead, keeping
+ * vue-component-meta and TypeScript out of the production server bundle.
  */
 export default defineEventHandler(async (event) => {
-  if (!import.meta.dev && !import.meta.prerender) {
-    throw createError({
-      statusCode: 404,
-      message: 'Component index is only available as a prerendered static asset.',
-    })
-  }
-
   const config = JSON.parse(readFileSync(configPath, 'utf-8'))
   const { prepareComponentIndex } = await import('../../utils/prepareComponentIndex')
   const componentIndexData = prepareComponentIndex(config)

--- a/test/verify-production-bundle.sh
+++ b/test/verify-production-bundle.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Verify the production build doesn't bundle vue-component-meta/TypeScript
+# and the component-index is correctly generated for both SSR and SSG.
+#
+# Usage: ./test/verify-production-bundle.sh
+#
+set -e
+
+cd "$(dirname "$0")/.."
+OUTPUT=playground/.output
+ERRORS=0
+
+check_index() {
+  local INDEX=$1
+  if [ -f "$INDEX" ] && grep -q '"components"' "$INDEX"; then
+    echo "PASS: component-index.json generated"
+  else
+    echo "FAIL: component-index.json not found or invalid"; ERRORS=$((ERRORS+1))
+  fi
+}
+
+# --- SSR Build ---
+echo "=== SSR Build (nuxt build) ==="
+rm -rf $OUTPUT
+NUXT_APP_CDN_URL=http://localhost:3000 npx nuxi build playground --quiet 2>&1 | tail -3
+
+check_index $OUTPUT/public/nuxt-component-preview/component-index.json
+
+SIZE=$(du -sb $OUTPUT/server/ | cut -f1)
+echo "Server bundle: $((SIZE / 1024))KB"
+if [ "$SIZE" -gt 3145728 ]; then
+  echo "FAIL: server bundle > 3MB — heavy deps likely bundled"
+  ERRORS=$((ERRORS+1))
+else
+  echo "PASS: server bundle under 3MB"
+fi
+
+# --- SSG Build ---
+echo ""
+echo "=== SSG Build (nuxt generate) ==="
+rm -rf $OUTPUT
+NUXT_APP_CDN_URL=http://localhost:3000 npx nuxi generate playground --quiet 2>&1 | tail -3
+
+check_index $OUTPUT/public/nuxt-component-preview/component-index.json
+
+echo ""
+echo "=== Results ==="
+[ $ERRORS -eq 0 ] && echo "ALL CHECKS PASSED" || { echo "$ERRORS CHECK(S) FAILED"; exit 1; }


### PR DESCRIPTION
Guard the vue-component-meta import with import.meta.dev and import.meta.prerender so rollup can tree-shake the dynamic import and the full TypeScript compiler (~8.7 MB) from production builds.

The component-index.json is prerendered during build and served as a static asset in production — the handler is never called at runtime.