### PR TITLE
chore: update lockfile for eslint 10 and vue-tsc 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10081,35 +10081,35 @@
       "license": "MIT"
     },
     "node_modules/mkdist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mkdist/-/mkdist-2.3.0.tgz",
-      "integrity": "sha512-thkRk+pHdudjdZT3FJpPZ2+pncI6mGlH/B+KBVddlZj4MrFGW41sRIv1wZawZUHU8v7cttGaj+5nx8P+dG664A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/mkdist/-/mkdist-2.4.1.tgz",
+      "integrity": "sha512-Ezk0gi04GJBkqMfsksICU5Rjoemc4biIekwgrONWVPor2EO/N9nBgN6MZXAf7Yw4mDDhrNyKbdETaHNevfumKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.21",
         "citty": "^0.1.6",
-        "cssnano": "^7.0.6",
+        "cssnano": "^7.1.1",
         "defu": "^6.1.4",
-        "esbuild": "^0.25.2",
+        "esbuild": "^0.25.9",
         "jiti": "^1.21.7",
-        "mlly": "^1.7.4",
+        "mlly": "^1.8.0",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.1.0",
-        "postcss": "^8.5.3",
+        "pkg-types": "^2.3.0",
+        "postcss": "^8.5.6",
         "postcss-nested": "^7.0.2",
-        "semver": "^7.7.1",
-        "tinyglobby": "^0.2.12"
+        "semver": "^7.7.2",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "mkdist": "dist/cli.cjs"
       },
       "peerDependencies": {
-        "sass": "^1.85.0",
-        "typescript": ">=5.7.3",
-        "vue": "^3.5.13",
+        "sass": "^1.92.1",
+        "typescript": ">=5.9.2",
+        "vue": "^3.5.21",
         "vue-sfc-transformer": "^0.1.1",
-        "vue-tsc": "^1.8.27 || ^2.0.21"
+        "vue-tsc": "^1.8.27 || ^2.0.21 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "sass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-component-preview",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-component-preview",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "vue-component-meta": "^3.1.0"
@@ -18,7 +18,7 @@
         "@nuxt/module-builder": "^1.0.1",
         "@nuxt/schema": "^4.2.1",
         "@nuxt/test-utils": "^3.20.1",
-        "@types/node": "*",
+        "@types/node": "latest",
         "@vue/test-utils": "^2.4.6",
         "eslint": "^10.0.0",
         "happy-dom": "^20.0.11",
@@ -3868,6 +3868,13 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
@@ -8010,18 +8017,19 @@
       }
     },
     "node_modules/eslint-plugin-import-x": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
-      "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.35.0",
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
         "comment-parser": "^1.4.1",
         "debug": "^4.4.1",
         "eslint-import-context": "^0.1.9",
         "is-glob": "^4.0.3",
-        "minimatch": "^9.0.3 || ^10.0.1",
+        "minimatch": "^9.0.3 || ^10.1.2",
         "semver": "^7.7.2",
         "stable-hash-x": "^0.2.0",
         "unrs-resolver": "^1.9.2"
@@ -8033,8 +8041,8 @@
         "url": "https://opencollective.com/eslint-plugin-import-x"
       },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "eslint-import-resolver-node": "*"
       },
       "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary
- Bumps `eslint-plugin-import-x` from 4.16.1 to 4.16.2 in the lockfile
- 4.16.2 adds `eslint ^10.0.0` peer dependency support, resolving the peer dep warning

No `package.json` changes — `eslint: "^10.0.0"` was already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)