### PR TITLE
fix: Resolve dev entry path relative to rootDir

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -88,11 +88,19 @@ export default defineNuxtModule<ModuleOptions>({
       })
     })
 
-    // Resolve entry path for dev
+    // Resolve entry path for dev.
+    // Vite serves files relative to the project root, so we need to
+    // convert the absolute appDir to a path relative to rootDir.
+    // Append buildId as cache buster so browser refetches after restart.
     if (nuxt.options.dev) {
       nuxt.hook('ready', () => {
-        const appDir = nuxt.options.appDir
-        resolvedEntryPath = `/_nuxt${appDir}/entry.js`
+        const appDir = nuxt.options.appDir.replace(/\/+$/, '')
+        const rootDir = nuxt.options.rootDir.replace(/\/+$/, '')
+        const relativeAppDir = appDir.startsWith(rootDir)
+          ? appDir.slice(rootDir.length + 1)
+          : appDir
+        const buildId = nuxt.options.appConfig?.nuxt?.buildId
+        resolvedEntryPath = `/_nuxt/${relativeAppDir}/entry.js` + (buildId ? `?v=${buildId}` : '')
       })
     }
 


### PR DESCRIPTION
## Summary

- Improves  dev entry URL to be relative - to match latest Vite/Nuxt behavior
- Adds `buildId` as `?v=` query param for cache busting across dev server restarts

