### PR TITLE
feat: support component-level name, description, and category from JSDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
-        "vue-component-meta": "^3.1.0"
+        "vue-component-meta": "^3.2.6"
       },
       "devDependencies": {
         "@nuxt/devtools": "^2.5.0",
@@ -5777,18 +5777,6 @@
       "integrity": "sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@volar/typescript": {
-      "version": "2.4.27",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.27.tgz",
-      "integrity": "sha512-eWaYCcl/uAPInSK2Lze6IqVWaBu/itVqR5InXcHXFyles4zO++Mglt3oxdgj75BDcv1Knr9Y93nowS8U3wqhxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@volar/language-core": "2.4.27",
-        "path-browserify": "^1.0.1",
-        "vscode-uri": "^3.0.8"
-      }
     },
     "node_modules/@vue-macros/common": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
-    "vue-component-meta": "^3.1.0"
+    "vue-component-meta": "^3.2.6"
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.5.0",

--- a/playground/components/global/TestHero.vue
+++ b/playground/components/global/TestHero.vue
@@ -15,6 +15,12 @@
 </template>
 
 <script setup lang="ts">
+/**
+ * Test Hero
+ * @description A hero section with title, description, and background image.
+ * @category Hero
+ * @status experimental
+ */
 withDefaults(defineProps<{
   /**
    * Hero title

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,8 @@ export interface ModuleOptions {
       directories?: string[] // Path patterns only (not packages)
     }
     overrides?: Record<string, {
+      name?: string
+      description?: string
       category?: string
       status?: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
     }>

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs'
+import { existsSync, statSync, readFileSync } from 'node:fs'
 import type { Component } from '@nuxt/schema'
 import { createChecker } from 'vue-component-meta'
 import { minimatch } from 'minimatch'
@@ -24,6 +24,8 @@ export interface ComponentIndexOptions {
   excludeDirectories?: string[]
   excludeComponents?: string[]
   overrides?: Record<string, {
+    name?: string
+    description?: string
     category?: string
     status?: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
   }>
@@ -65,6 +67,106 @@ export function resolveCategory(category: string | CategoryDirectoryOptions, sho
   }
 
   return 'Components'
+}
+
+/**
+ * Component-level metadata extracted from JSDoc in <script setup>.
+ */
+export interface ComponentMeta {
+  name?: string
+  description?: string
+  category?: string
+  status?: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
+}
+
+/**
+ * Extract component-level metadata from the first JSDoc comment in <script setup>.
+ *
+ * The first JSDoc block before any code is treated as component metadata:
+ * - First line → custom display name (if short enough)
+ * - @description tag → component description
+ * - @category tag → category override
+ * - @status tag → status override (experimental, stable, deprecated, obsolete)
+ *
+ * Also checks vue-component-meta's description field (works with export default).
+ *
+ */
+export function extractComponentMeta(filePath: string, vcmDescription?: string): ComponentMeta {
+  const result: ComponentMeta = {}
+
+  // Use vue-component-meta description if available (from export default JSDoc)
+  if (vcmDescription) {
+    const lines = vcmDescription.split('\n')
+    const firstLine = lines[0].trim()
+    if (firstLine && firstLine.length <= 50) {
+      result.name = firstLine
+    }
+    if (lines.length > 1) {
+      result.description = lines.slice(1).join('\n').trim() || undefined
+    }
+    else {
+      result.description = firstLine
+    }
+    return result
+  }
+
+  // Parse <script setup> for component-level JSDoc
+  try {
+    const source = readFileSync(filePath, 'utf-8')
+    const scriptMatch = source.match(/<script\s[^>]*setup[^>]*>([\s\S]*?)<\/script>/)
+    if (!scriptMatch) return result
+
+    const script = scriptMatch[1]
+    // Find the first JSDoc comment that appears before any code
+    const jsdocMatch = script.match(/^\s*\/\*\*([\s\S]*?)\*\//)
+    if (!jsdocMatch) return result
+
+    const comment = jsdocMatch[1]
+    const lines = comment
+      .split('\n')
+      .map(line => line.replace(/^\s*\*\s?/, '').trim())
+      .filter(line => line.length > 0)
+
+    // Extract @description tag
+    const descTag = lines.find(l => l.startsWith('@description '))
+    if (descTag) {
+      result.description = descTag.replace('@description ', '').trim()
+    }
+
+    // Extract @category tag
+    const catTag = lines.find(l => l.startsWith('@category '))
+    if (catTag) {
+      result.category = catTag.replace('@category ', '').trim()
+    }
+
+    // Extract @status tag
+    const statusTag = lines.find(l => l.startsWith('@status '))
+    if (statusTag) {
+      const statusValue = statusTag.replace('@status ', '').trim()
+      if (['experimental', 'stable', 'deprecated', 'obsolete'].includes(statusValue)) {
+        result.status = statusValue as ComponentMeta['status']
+      }
+    }
+
+    // First non-tag line is the name (if short enough)
+    const firstNonTag = lines.find(l => !l.startsWith('@'))
+    if (firstNonTag && firstNonTag.length <= 50) {
+      result.name = firstNonTag
+    }
+
+    // If no @description, use remaining non-tag lines after first as description
+    if (!result.description) {
+      const nonTagLines = lines.filter(l => !l.startsWith('@'))
+      if (nonTagLines.length > 1) {
+        result.description = nonTagLines.slice(1).join(' ').trim() || undefined
+      }
+    }
+  }
+  catch {
+    // Ignore parse errors
+  }
+
+  return result
 }
 
 interface PropDefinition {
@@ -892,14 +994,19 @@ export function generateComponentIndex(
           return acc
         }, {} as Record<string, SlotDefinition>)
 
-      // Apply overrides if present
+      // Extract component-level metadata from JSDoc and vue-component-meta
+      const componentMeta = extractComponentMeta(component.filePath, meta.description)
+
+      // Apply overrides if present (overrides take priority over JSDoc)
       const override = options.overrides?.[component.pascalName]
 
+      const description = override?.description || componentMeta.description
       return {
         id: component.pascalName,
-        name: generateTitle(component.pascalName),
-        category: override?.category || resolveCategory(options.category, component.shortPath),
-        status: override?.status || options.status,
+        name: override?.name || componentMeta.name || generateTitle(component.pascalName),
+        ...(description && { description }),
+        category: override?.category || componentMeta.category || resolveCategory(options.category, component.shortPath),
+        status: override?.status || componentMeta.status || options.status,
         props: {
           type: 'object',
           properties: props,

--- a/test/component-index.test.ts
+++ b/test/component-index.test.ts
@@ -402,4 +402,132 @@ describe('Component Index Generation', () => {
       expect(result.components[0].category).toBe('Custom Override')
     }, 10000)
   })
+
+  describe('extractComponentMeta', () => {
+    it('extracts name, description, and category from script setup JSDoc', async () => {
+      const { extractComponentMeta } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const meta = extractComponentMeta(
+        resolve(process.cwd(), 'playground/components/global/TestHero.vue'),
+      )
+
+      expect(meta.name).toBe('Test Hero')
+      expect(meta.description).toBe('A hero section with title, description, and background image.')
+      expect(meta.category).toBe('Hero')
+      expect(meta.status).toBe('experimental')
+    })
+
+    it('returns empty meta when no component JSDoc', async () => {
+      const { extractComponentMeta } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const meta = extractComponentMeta(
+        resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+      )
+
+      expect(meta.name).toBeUndefined()
+      expect(meta.description).toBeUndefined()
+      expect(meta.category).toBeUndefined()
+    })
+
+    it('prefers vue-component-meta description when available', async () => {
+      const { extractComponentMeta } = await import('../src/runtime/server/utils/generateComponentIndex')
+
+      const meta = extractComponentMeta(
+        '/nonexistent.vue',
+        'Custom Name\n\nA description from export default.',
+      )
+
+      expect(meta.name).toBe('Custom Name')
+      expect(meta.description).toBe('A description from export default.')
+    })
+  })
+
+  describe('component metadata integration', () => {
+    it('uses JSDoc name and description in component index', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'TestHero',
+          kebabName: 'test-hero',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestHero.vue'),
+          shortPath: 'components/global/TestHero.vue',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        { category: 'Default', status: 'stable' },
+      )
+
+      const hero = result.components[0]
+      expect(hero.name).toBe('Test Hero')
+      expect(hero.description).toBe('A hero section with title, description, and background image.')
+      expect(hero.category).toBe('Hero')
+      expect(hero.status).toBe('experimental')
+    }, 10000)
+
+    it('override takes priority over JSDoc', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'TestHero',
+          kebabName: 'test-hero',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestHero.vue'),
+          shortPath: 'components/global/TestHero.vue',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        {
+          category: 'Default',
+          status: 'stable',
+          overrides: {
+            TestHero: { name: 'Override Name', description: 'Override desc', category: 'Override Cat' },
+          },
+        },
+      )
+
+      const hero = result.components[0]
+      expect(hero.name).toBe('Override Name')
+      expect(hero.description).toBe('Override desc')
+      expect(hero.category).toBe('Override Cat')
+    }, 10000)
+
+    it('falls back to generated name when no JSDoc', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'TestCard',
+          kebabName: 'test-card',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+          shortPath: 'components/global/TestCard.vue',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        { category: 'Default', status: 'stable' },
+      )
+
+      const card = result.components[0]
+      expect(card.name).toBe('Test Card')
+      expect(card.description).toBeUndefined()
+      expect(card.category).toBe('Default')
+    }, 10000)
+  })
 })


### PR DESCRIPTION
Claude Code:

## Summary

Extract component-level metadata from JSDoc comments in `<script setup>`, enabling custom names, descriptions, and categories without config overrides.

## Usage

```vue
<script setup lang="ts">
/**
 * Hero CTA
 * @description A call to action with heading, text, and action buttons.
 * @category Hero
 */
```

- **First line** → custom display name (e.g., "Hero CTA" instead of auto-generated "Hero Cta")
- **@description** → component description shown in Canvas editor
- **@category** → category override (alternative to directory-based or config-based)

All fields are optional. Falls back to auto-generated name, no description, and config-based category.

## Priority chain

1. Config overrides (`componentIndex.overrides`)
2. `vue-component-meta` description (from `export default` JSDoc)
3. `<script setup>` JSDoc (parsed by this feature)
4. Auto-generated from PascalName

## Test coverage

- `extractComponentMeta` unit tests (JSDoc parsing, vue-component-meta fallback, empty case)
- Integration tests (JSDoc in component index output, override priority, fallback behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)