### PR TITLE
fix: preserve enum value ordering from TypeScript union types

### DIFF
--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import type { Component } from '@nuxt/schema'
 import { createChecker } from 'vue-component-meta'
 import { minimatch } from 'minimatch'
@@ -868,8 +868,11 @@ export function generateComponentIndex(
 
           if (prop.default !== undefined) propDef.default = parseDefaultValue(prop.default)
 
-          // Extract enum from TypeScript union types
-          const enumValues = extractEnumFromType(prop.type)
+          // Extract enum from TypeScript union types.
+          // Use declaration source order when available, as vue-component-meta
+          // may reorder union types (e.g., placing the default value first).
+          const enumValues = extractEnumFromDeclaration(prop, component.filePath)
+            ?? extractEnumFromType(prop.type)
           if (enumValues.length > 0) {
             propDef.enum = enumValues
             const metaEnum = extractEnumLabels(prop, enumValues)
@@ -941,6 +944,40 @@ function extractEnumFromType(type: string): string[] {
   }
 
   return []
+}
+
+/**
+ * Extract enum values in their original source order using vue-component-meta's
+ * declaration range.
+ *
+ * vue-component-meta may reorder union types (e.g., placing the default value
+ * first). This function uses getDeclarations() to read the original prop
+ * declaration from the source file and extract values in the authored order.
+ *
+ * @returns The enum values in source order, or null if extraction fails
+ */
+function extractEnumFromDeclaration(
+  prop: { getDeclarations?: () => Array<{ file: string, range: number[] }> },
+  filePath: string,
+): string[] | null {
+  try {
+    const decls = prop.getDeclarations?.()
+    if (!decls?.[0]?.range) return null
+
+    const source = readFileSync(decls[0].file || filePath, 'utf-8')
+    const text = source.substring(decls[0].range[0], decls[0].range[1])
+
+    // Extract quoted string values from the union type declaration
+    const values = text.match(/['"]([^'"]+)['"]/g)
+    if (values && values.length > 1) {
+      return values.map(v => v.replace(/['"]/g, ''))
+    }
+
+    return null
+  }
+  catch {
+    return null
+  }
 }
 
 function mapVueTypeToJsonSchema(vueType: string): string {

--- a/test/component-index.test.ts
+++ b/test/component-index.test.ts
@@ -110,6 +110,34 @@ describe('Component Index Generation', () => {
       // Title is extracted from JSDoc first line
       expect(component.props.properties.label.title).toBe('Button label text')
     }, 10000)
+
+    it('preserves enum value ordering from TypeScript union types', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [{
+        pascalName: 'TestButton',
+        filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+        global: true,
+      }]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        { category: 'Test', status: 'stable' },
+      )
+
+      const component = result.components[0]
+
+      // size is defined as 'small' | 'medium' | 'large' with default 'medium'
+      // The enum order must match the TypeScript union type, not be reordered
+      // by the default value.
+      expect(component.props.properties.size.enum).toEqual(['small', 'medium', 'large'])
+
+      // variant is defined as 'primary' | 'secondary' | 'danger' | 'success'
+      // with default 'primary' - order must be preserved.
+      expect(component.props.properties.variant.enum).toEqual(['primary', 'secondary', 'danger', 'success'])
+    }, 10000)
   })
 
   describe('Step 2: Default Category/Status + Validation', () => {


### PR DESCRIPTION
Claude Code: This PR was created by Claude Code.

## Summary

- Fixes a bug where enum values in the component-index JSON were reordered, with the default value moved to the first position instead of preserving the order from the TypeScript union type
- The root cause is that `vue-component-meta` reorders union types, placing the default value first (e.g., `'small' | 'medium' | 'large'` with default `'medium'` becomes `"medium" | "small" | "large"`)
- Added `extractEnumOrderFromSource()` which reads the original Vue source file to extract the union type in its original order, falling back to the `vue-component-meta` type string if source parsing fails

## Test plan

- [x] Added test verifying `size` enum order matches `['small', 'medium', 'large']` (not `['medium', 'small', 'large']`)
- [x] Added test verifying `variant` enum order matches `['primary', 'secondary', 'danger', 'success']`
- [x] All 21 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)