### PR TITLE
fix: mark props as required when they are not optional

### DIFF
--- a/playground/components/global/TestBanner.vue
+++ b/playground/components/global/TestBanner.vue
@@ -12,17 +12,16 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
+defineProps<{
   /**
-   * Banner heading
+   * Banner heading (required)
+   * @example Welcome to our site
    */
-  heading?: string
+  heading: string
   /**
    * Banner image using key-value syntax
    * @example src=https://placehold.co/600x400 alt="Banner image" width=600 height=400
    */
   image?: CanvasImage
-}>(), {
-  heading: 'Default Banner',
-})
+}>()
 </script>

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -791,6 +791,7 @@ interface ComponentDefinition {
   status: string
   props: {
     type: 'object'
+    required?: string[]
     properties: Record<string, PropDefinition>
   }
   slots?: Record<string, SlotDefinition>
@@ -987,6 +988,13 @@ export function generateComponentIndex(
           return acc
         }, {} as Record<string, PropDefinition>)
 
+      // Collect required prop names (props without ? in TypeScript and no default)
+      const requiredProps = meta.props
+        .filter(p => !vueInternalProps.includes(p.name))
+        .filter(p => !p.name.startsWith('onVue:'))
+        .filter(p => p.required)
+        .map(p => p.name)
+
       // Extract slots
       const slots = meta.slots
         .reduce((acc, slot) => {
@@ -1012,6 +1020,7 @@ export function generateComponentIndex(
         status: override?.status || componentMeta.status || options.status,
         props: {
           type: 'object',
+          ...(requiredProps.length > 0 && { required: requiredProps }),
           properties: props,
         },
         ...(Object.keys(slots).length > 0 && { slots }),

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -210,6 +210,35 @@ describe('Component Index - Prop Metadata Extraction', () => {
     })
   })
 
+  // ── Required vs optional props ───────────────────────────────────
+  describe('required vs optional props', () => {
+    let result: ComponentIndexData
+
+    beforeAll(async () => {
+      result = await generateIndex([createMockComp('TestBanner', 'TestBanner.vue')])
+    })
+
+    it('includes required array for non-optional props', () => {
+      const component = result.components[0]
+      // heading is required (no ? in TypeScript, no default)
+      expect(component.props.required).toBeDefined()
+      expect(component.props.required).toContain('heading')
+    })
+
+    it('does not include optional props in required array', () => {
+      const component = result.components[0]
+      // image is optional (has ? in TypeScript)
+      expect(component.props.required).not.toContain('image')
+    })
+
+    it('omits required array when all props are optional', async () => {
+      const allOptional = await generateIndex([createMockComp('TestCard', 'TestCard.vue')])
+      const component = allOptional.components[0]
+      // TestCard has only optional props with defaults
+      expect(component.props.required).toBeUndefined()
+    })
+  })
+
   // ── TestCard group ────────────────────────────────────────────────
   describe('TestCard props', () => {
     let result: ComponentIndexData


### PR DESCRIPTION
## Summary

- `vue-component-meta` provides a `required` boolean per prop, but `generateComponentIndex` never used it
-  fix it correctly provide required metadata


