### PR TITLE
feat: Add component index option to limit included directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ export default defineNuxtConfig({
       // Or use a static string:
       // category: 'Nuxt Components',
 
+      // Include only components from specific directories (by path pattern).
+      // When set, everything outside these directories is excluded.
+      include: {
+        directories: ['Canvas'], // Only index components under Canvas/
+      },
+
       // Exclude components (overwrites defaults)
       exclude: {
         components: ['*--default'], // default: excludes *--default pattern
@@ -169,6 +175,24 @@ The `includePackages` option controls which npm package components are included 
 - `['package-name', '@org/package']`: Only components from specified packages are processed
 
 Only affects components registered globally by Nuxt from npm packages.
+
+#### Directory Filtering
+
+The `include.directories` option restricts the component index to components in specific directories:
+
+```typescript
+componentPreview: {
+  componentIndex: {
+    include: {
+      directories: ['Canvas'], // Only components under a Canvas/ directory
+    },
+  },
+}
+```
+
+This matches against the component's `shortPath` using glob patterns (`**/Canvas/**`). It works for both app-level components (`components/Canvas/...`) and package-layer components (`packages/my-layer/components/Canvas/...`).
+
+Use `exclude.directories` to further narrow within the included set — e.g., include `Canvas` but exclude `Canvas/Internal`.
 
 ### Component Metadata
 

--- a/README.md
+++ b/README.md
@@ -178,21 +178,12 @@ Only affects components registered globally by Nuxt from npm packages.
 
 #### Directory Filtering
 
-The `include.directories` option restricts the component index to components in specific directories:
+Filter the component index by directory path patterns. Works for both app-level and package-layer components.
 
-```typescript
-componentPreview: {
-  componentIndex: {
-    include: {
-      directories: ['Canvas'], // Only components under a Canvas/ directory
-    },
-  },
-}
-```
+- `include.directories`: when set, **only** components in these directories are indexed
+- `exclude.directories`: exclude components in these directories
 
-This matches against the component's `shortPath` using glob patterns (`**/Canvas/**`). It works for both app-level components (`components/Canvas/...`) and package-layer components (`packages/my-layer/components/Canvas/...`).
-
-Use `exclude.directories` to further narrow within the included set — e.g., include `Canvas` but exclude `Canvas/Internal`.
+Both can be combined — e.g., include `Canvas` but exclude `Canvas/Internal`.
 
 ### Component Metadata
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ export default defineNuxtConfig({
         directories: [] // exclude by directory pattern
       },
 
-      // Package filtering for component index (default: false = exclude all packages)
-      includePackages: false,           // Exclude all package components from node_modules
-      // includePackages: true,          // Include all package components (not recommended)
-      // includePackages: ['my-package'], // Include only components from specific packages
+      // Include components from npm packages in node_modules (default: false)
+      includePackages: false,           // Exclude all npm package components
+      // includePackages: true,          // Include all npm package components
+      // includePackages: ['my-package'], // Include only specific npm packages
 
       // Override metadata for specific components
       overrides: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-component-preview",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "A Nuxt module for component previewing functionality",
   "repository": "drunomics/nuxt-component-preview",
   "license": "MIT",

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,6 +14,9 @@ export interface ModuleOptions {
     category?: string | CategoryDirectoryOptions
     status?: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
     includePackages?: boolean | string[] // false = exclude all (default), array = include only these
+    include?: {
+      directories?: string[] // When set, only components in these directories are indexed
+    }
     exclude?: {
       components?: string[]
       directories?: string[] // Path patterns only (not packages)
@@ -38,6 +41,9 @@ export default defineNuxtModule<ModuleOptions>({
       category: 'Nuxt Components',
       status: 'stable',
       includePackages: false, // By default, exclude all packages from node_modules
+      include: {
+        directories: [], // When set, only components in these directories are indexed
+      },
       exclude: {
         components: ['*--default', 'drupal-*'],
         directories: [], // Path patterns only
@@ -178,6 +184,7 @@ export default defineNuxtModule<ModuleOptions>({
         category: options.componentIndex!.category!,
         status: options.componentIndex!.status!,
         includePackages: options.componentIndex!.includePackages,
+        includeDirectories: options.componentIndex!.include!.directories,
         excludeDirectories: options.componentIndex!.exclude!.directories,
         excludeComponents: options.componentIndex!.exclude!.components,
         overrides: options.componentIndex!.overrides,

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -21,6 +21,7 @@ export interface ComponentIndexOptions {
   category: string | CategoryDirectoryOptions
   status: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
   includePackages?: boolean | string[] // false = exclude all packages, array = include only these
+  includeDirectories?: string[] // When set, only components in these directories are indexed
   excludeDirectories?: string[]
   excludeComponents?: string[]
   overrides?: Record<string, {
@@ -844,6 +845,14 @@ export function generateComponentIndex(
         }
       }
       // If includePackages === true, include all packages (no filtering)
+    }
+
+    // Check directory inclusions — when set, only keep components in these directories
+    if (options.includeDirectories && options.includeDirectories.length > 0) {
+      const included = options.includeDirectories.some(pattern =>
+        minimatch(c.shortPath, `**/${pattern}/**`),
+      )
+      if (!included) return false
     }
 
     // Check directory exclusions (path patterns only)

--- a/test/component-index.test.ts
+++ b/test/component-index.test.ts
@@ -222,6 +222,127 @@ describe('Component Index Generation', () => {
     })
   })
 
+  describe('Directory Inclusions', () => {
+    it('includes only components from specified directories', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'TestButton',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'components/global/TestButton.vue',
+          kebabName: 'test-button',
+          global: true,
+        },
+        {
+          pascalName: 'CanvasHero',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'components/Canvas/Hero/CanvasHero.vue',
+          kebabName: 'canvas-hero',
+          global: true,
+        },
+        {
+          pascalName: 'CanvasCard',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+          shortPath: 'components/Canvas/Base/CanvasCard.vue',
+          kebabName: 'canvas-card',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        {
+          category: 'Test',
+          status: 'stable',
+          includeDirectories: ['Canvas'],
+        },
+      )
+
+      expect(result.components).toHaveLength(2)
+      expect(result.components.map(c => c.id)).toEqual(['CanvasHero', 'CanvasCard'])
+    }, 10000)
+
+    it('does not filter when includeDirectories is empty', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'TestButton',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'components/global/TestButton.vue',
+          kebabName: 'test-button',
+          global: true,
+        },
+        {
+          pascalName: 'TestCard',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+          shortPath: 'components/global/TestCard.vue',
+          kebabName: 'test-card',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        {
+          category: 'Test',
+          status: 'stable',
+          includeDirectories: [],
+        },
+      )
+
+      expect(result.components).toHaveLength(2)
+    }, 10000)
+
+    it('works together with excludeDirectories', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'CanvasHero',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'components/Canvas/Hero/CanvasHero.vue',
+          kebabName: 'canvas-hero',
+          global: true,
+        },
+        {
+          pascalName: 'CanvasInternal',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+          shortPath: 'components/Canvas/Internal/CanvasInternal.vue',
+          kebabName: 'canvas-internal',
+          global: true,
+        },
+        {
+          pascalName: 'MarketingBanner',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'components/Marketing/Banner/MarketingBanner.vue',
+          kebabName: 'marketing-banner',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        {
+          category: 'Test',
+          status: 'stable',
+          includeDirectories: ['Canvas'],
+          excludeDirectories: ['Canvas/Internal'],
+        },
+      )
+
+      expect(result.components).toHaveLength(1)
+      expect(result.components[0].id).toBe('CanvasHero')
+    }, 10000)
+  })
+
   describe('Step 5: Component Name Exclusions', () => {
     it('excludes components by name pattern', async () => {
       const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')

--- a/test/component-index.test.ts
+++ b/test/component-index.test.ts
@@ -341,6 +341,52 @@ describe('Component Index Generation', () => {
       expect(result.components).toHaveLength(1)
       expect(result.components[0].id).toBe('CanvasHero')
     }, 10000)
+
+    it('matches components from package layers (deep shortPath)', async () => {
+      const { generateComponentIndex } = await import('../src/runtime/server/utils/generateComponentIndex')
+      const { resolve } = await import('node:path')
+
+      const mockComponents = [
+        {
+          pascalName: 'BaseHeading',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'packages/my-kickstart-components/components/Canvas/Base/base-heading.vue',
+          kebabName: 'base-heading',
+          global: true,
+        },
+        {
+          pascalName: 'MarketingHero',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestButton.vue'),
+          shortPath: 'packages/my-kickstart-components/components/Marketing/marketing-hero.vue',
+          kebabName: 'marketing-hero',
+          global: true,
+        },
+        {
+          pascalName: 'AppLocalCanvas',
+          filePath: resolve(process.cwd(), 'playground/components/global/TestCard.vue'),
+          shortPath: 'components/Canvas/Card/app-card.vue',
+          kebabName: 'app-card',
+          global: true,
+        },
+      ]
+
+      const result = generateComponentIndex(
+        mockComponents as MockComponent[],
+        resolve(process.cwd(), 'playground/tsconfig.json'),
+        {
+          category: 'Test',
+          status: 'stable',
+          includeDirectories: ['Canvas'],
+        },
+      )
+
+      // Both package-layer and app-level Canvas components included
+      expect(result.components).toHaveLength(2)
+      const ids = result.components.map((c: { id: string }) => c.id)
+      expect(ids).toContain('BaseHeading')
+      expect(ids).toContain('AppLocalCanvas')
+      expect(ids).not.toContain('MarketingHero')
+    }, 10000)
   })
 
   describe('Step 5: Component Name Exclusions', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,8 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
   test: {
-    pool: 'forks',
-    teardownTimeout: 30000,
+    // Prevents vitest worker RPC timeout ("onTaskUpdate") in CI
+    // with the heavy @nuxt/test-utils environment.
     fileParallelism: false,
     environment: 'nuxt',
     environmentOptions: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 export default defineVitestConfig({
   test: {
     pool: 'forks',
+    teardownTimeout: 30000,
     environment: 'nuxt',
     environmentOptions: {
       nuxt: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
   test: {
+    pool: 'forks',
     environment: 'nuxt',
     environmentOptions: {
       nuxt: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineVitestConfig({
   test: {
     pool: 'forks',
     teardownTimeout: 30000,
+    fileParallelism: false,
     environment: 'nuxt',
     environmentOptions: {
       nuxt: {


### PR DESCRIPTION
## Summary

Adds `include.directories` option to the component index config. When set, ONLY components from the listed directories are included — everything else is excluded.

```ts
componentPreview: {
  componentIndex: {
    include: {
      directories: ['Canvas'],
    },
  },
}
```

## Use case

The Starter has Canvas components in `components/Canvas/` alongside other components in `components/global/` etc. Currently requires `excludeDirectories` to list that specifically. With `include.directories: ['Canvas']`, only Canvas components appear in the index.

## Changes

- `src/module.ts`: Added `include.directories` to options interface and defaults
- `src/runtime/server/utils/generateComponentIndex.ts`: Added filtering logic using minimatch (same pattern style as `excludeDirectories`)
- `test/component-index.test.ts`: 3 new tests (include only, empty array, combined with excludeDirectories)

## Test plan

- [x] All 30 tests pass (27 existing + 3 new)
- [x] Module builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)