### PR TITLE
perf: Use DocumentFragment for batch slot child moves

### DIFF
--- a/src/runtime/components/ComponentPreviewAreaDrupalCe.vue
+++ b/src/runtime/components/ComponentPreviewAreaDrupalCe.vue
@@ -28,11 +28,14 @@ function renderComponent(preview) {
           return h('div', {
             ref: (el) => {
               if (el && content.childNodes.length > 0) {
-                // Move all children from the slot container to this Vue slot element
+                // Use DocumentFragment to batch-move all children in a single
+                // DOM insertion, avoiding N separate reflows.
+                const fragment = document.createDocumentFragment()
                 while (content.firstChild) {
-                  el.appendChild(content.firstChild)
+                  fragment.appendChild(content.firstChild)
                 }
-                // Remove the now-empty wrapper
+                el.appendChild(fragment)
+                // Remove the now-empty wrapper.
                 content.remove()
               }
             },


### PR DESCRIPTION
## Summary

- Use `DocumentFragment` to batch-move all slot children in a single DOM insertion instead of N separate `appendChild` calls
- Reduces potential reflows from N to 1 when moving slot content into Vue components in `ComponentPreviewAreaDrupalCe.vue`

## Test plan

- [ ] Open canvas editor with ExtJS components that have slots
- [ ] Verify components render correctly with slot content
- [ ] No visual difference - this is a performance optimization only

🤖 Generated with [Claude Code](https://claude.com/claude-code)