### PR TITLE
feat: Add updateComponent callback for real-time preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ Add the `<ComponentPreviewArea />` to your `app.vue` so previews render when pre
 
 For embedding previews in external pages (e.g., Drupal Canvas editor), see the [App Loader documentation](./docs/app-loader.md).
 
+### Updating Component Props
+
+After `$previewComponent()` resolves, the target element has an `updateComponent()` method that allows updating props in-place without re-mounting:
+
+```javascript
+const { unmount } = await nuxtApp.$previewComponent('MyComponent', props, {}, '#target');
+
+// Later: update props in-place, triggers Vue re-render.
+document.querySelector('#target').updateComponent({ title: 'New title' });
+```
+
+This is used by [canvas_extjs](https://www.drupal.org/project/canvas_extjs) for real-time preview updates in the Canvas editor.
+
 ## Component Index
 
 This module automatically generates a component index JSON file containing metadata for all global components. This is particularly useful for integration with [Drupal Canvas External JS](https://www.drupal.org/project/canvas_extjs) module.

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -41,6 +41,20 @@ export default defineNuxtPlugin((nuxtApp) => {
     // Wait for Vue to render the component.
     await nextTick()
 
+    // Set updateComponent callback for real-time preview updates. This allows
+    // canvas_extjs to update component props in-place without a full page
+    // re-render. The callback merges new props into the reactive preview state,
+    // triggering Vue to re-render the component.
+    if (props['data-extjs-uuid']) {
+      targetEl.setAttribute('data-extjs-uuid', props['data-extjs-uuid'])
+      targetEl.updateComponent = (propUpdates) => {
+        const proxy = previews.value.find(p => p.target === targetEl)
+        if (!proxy) return false
+        proxy.content.props = { ...proxy.content.props, ...propUpdates }
+        return true
+      }
+    }
+
     return {
       unmount() {
         previews.value = previews.value.filter(c => c.target !== targetEl)

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -41,23 +41,26 @@ export default defineNuxtPlugin((nuxtApp) => {
     // Wait for Vue to render the component.
     await nextTick()
 
-    // Set updateComponent callback for real-time preview updates. This allows
-    // canvas_extjs to update component props in-place without a full page
-    // re-render. The callback merges new props into the reactive preview state,
-    // triggering Vue to re-render the component.
+    // Copy data-extjs-uuid to the target element so canvas_extjs can find
+    // it via querySelector for real-time preview updates.
     if (props['data-extjs-uuid']) {
       targetEl.setAttribute('data-extjs-uuid', props['data-extjs-uuid'])
-      targetEl.updateComponent = (propUpdates) => {
-        const proxy = previews.value.find(p => p.target === targetEl)
-        if (!proxy) return false
-        proxy.content.props = { ...proxy.content.props, ...propUpdates }
-        return true
-      }
+    }
+
+    // Set updateComponent on the target element so props can be updated
+    // in-place without a full re-render. Callers can use this for real-time
+    // preview updates or any prop patching scenario.
+    targetEl.updateComponent = (propUpdates) => {
+      const proxy = previews.value.find(p => p.target === targetEl)
+      if (!proxy) return false
+      proxy.content.props = { ...proxy.content.props, ...propUpdates }
+      return true
     }
 
     return {
       unmount() {
         previews.value = previews.value.filter(c => c.target !== targetEl)
+        delete targetEl.updateComponent
       },
     }
   }

--- a/test/e2e/preview-dev.test.ts
+++ b/test/e2e/preview-dev.test.ts
@@ -134,6 +134,43 @@ describe('preview E2E (dev mode)', async () => {
     })
   })
 
+  describe('updateComponent', () => {
+    it('updates props in-place and triggers re-render', async () => {
+      const page = await createPage('/preview-test-loader.html')
+
+      // Wait for component to render
+      await page.waitForFunction(() => {
+        const target = document.getElementById('preview-buttons')
+        return target && target.children.length > 0
+          && target.innerHTML.includes('Primary Button')
+      }, { timeout: 15000 })
+
+      // Call updateComponent to change the label
+      const updated = await page.evaluate(() => {
+        const target = document.getElementById('preview-buttons')
+        if (!target?.updateComponent) return { hasMethod: false }
+        const result = target.updateComponent({ label: 'Updated Label' })
+        return { hasMethod: true, result }
+      })
+
+      expect(updated.hasMethod).toBe(true)
+      expect(updated.result).toBe(true)
+
+      // Wait for Vue to re-render with new props
+      await page.waitForFunction(() => {
+        const target = document.getElementById('preview-buttons')
+        return target?.innerHTML.includes('Updated Label')
+      }, { timeout: 5000 })
+
+      const content = await page.evaluate(() => {
+        return document.getElementById('preview-buttons')?.innerHTML.includes('Updated Label')
+      })
+
+      expect(content).toBe(true)
+      await page.close()
+    })
+  })
+
   describe('without app-loader.js (manual setup)', () => {
     it('works with manually configured HTML', async () => {
       const page = await createPage('/preview-test.html')


### PR DESCRIPTION
## Summary

- Adds `updateComponent()` callback on the Teleport target element when `data-extjs-uuid` is present in component props
- Enables canvas_extjs to update component props in-place without a full page re-render
- The callback merges new props into the reactive preview state, triggering Vue to re-render

This is the provider-side implementation for canvas_extjs real-time preview updates ([#3552861](https://www.drupal.org/project/canvas_extjs/issues/3552861)).

## How it works

1. canvas_extjs sets `data-extjs-uuid` on components in preview mode
2. `$previewComponent()` detects this prop and sets `updateComponent()` on the target element
3. canvas_extjs's editor-side listener calls `updateComponent({ propName: value })` for scalar prop changes
4. Vue reactivity re-renders the component instantly

## Test plan

- [ ] Open canvas editor with ExtJS components
- [ ] Edit a scalar prop (text, number) in the sidebar
- [ ] Component should update in preview without full page reload
- [ ] Non-scalar props still trigger normal server round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)