### PR TITLE
feat\!: Change componentPreview runtime config from boolean to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add the `<ComponentPreviewArea />` to your `app.vue` so previews render when pre
 
 ```vue
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview?.active" />
   <NuxtPage v-else />
 </template>
 ```

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview?.active" />
   <NuxtPage v-else />
 </template>
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -73,7 +73,7 @@
 
     <div style="margin: 2rem 0;">
       <h2>Module Status</h2>
-      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreview ? 'Enabled' : 'Disabled' }}</p>
+      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreview?.active ? 'Enabled' : 'Disabled' }}</p>
       <p>Preview mode should be disabled in normal app usage and only enabled when explicitly configured.</p>
     </div>
   </div>

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -3,7 +3,7 @@ import { defineNuxtPlugin, useState, useRuntimeConfig, onNuxtReady, nextTick } f
 export default defineNuxtPlugin((nuxtApp) => {
   // Only activate when preview mode is enabled
   const config = useRuntimeConfig()
-  if (!config.public.componentPreview) {
+  if (!config.public.componentPreview?.active) {
     return
   }
 

--- a/src/runtime/router.options.ts
+++ b/src/runtime/router.options.ts
@@ -5,7 +5,7 @@ export default <RouterConfig>{
   // Only change history mode on client when preview mode is enabled
   history: (base) => {
     if (import.meta.client && typeof window !== 'undefined') {
-      const previewMode = useNuxtApp().payload.config?.public?.componentPreview
+      const previewMode = useNuxtApp().payload.config?.public?.componentPreview?.active
       if (previewMode) {
         console.log('[Component Preview] Using memory history')
         return createMemoryHistory(base)

--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -24,11 +24,12 @@ export default defineEventHandler((event) => {
       : `${requestURL.protocol}//${requestURL.host}`
   }
 
-  // Serialize public config (with componentPreview enabled)
-  // Only include what's needed for the client
+  // Serialize public config, merging `active: true` into componentPreview
+  // so any build-time componentPreview options (e.g. cdnFetchPaths) survive.
+  const existing = (config.public.componentPreview as Record<string, unknown>) ?? {}
   const publicConfig = {
     ...config.public,
-    componentPreview: true,
+    componentPreview: { ...existing, active: true },
   }
   const publicConfigStr = JSON.stringify(publicConfig)
   const entryCssPathsStr = JSON.stringify(entryCssPaths || [])

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,7 +27,10 @@ describe('nuxt-component-preview module', async () => {
     })
     expect(typeof script).toBe('string')
     expect(script).toContain('function initNuxt()')
-    expect(script).toContain('componentPreview')
+    // Activates preview mode via `componentPreview.active = true` (object
+    // shape, merged with any build-time componentPreview public config).
+    expect(script).toContain('"componentPreview":{')
+    expect(script).toContain('"active":true')
   })
 
   it('component index includes subfolder components with folder-prefixed names', async () => {


### PR DESCRIPTION
## Summary

**Breaking change.** `runtimeConfig.public.componentPreview` was a plain boolean flag set by `app-loader.js` at runtime. Because the whole value was overwritten with `true`, no other options could live under the same namespace — which complicated adding e.g. `cdnFetchPaths` (PR #164, now using a separate `nuxtComponentPreview` key as a workaround).

This PR changes the shape to an object:

```ts
componentPreview: { active: true, /* other options */ }
```

`app-loader.js` now **merges** `active: true` into whatever `componentPreview` value was already in `runtimeConfig.public`, so build-time options survive. After this lands, PR #164 can move `cdnFetchPaths` under `componentPreview.cdnFetchPaths` and drop the separate key.

## Migration

Replace any boolean check with `.active`:

```diff
- v-if="config.public.componentPreview"
+ v-if="config.public.componentPreview?.active"
```

## Test plan

- [x] `test/basic.test.ts` asserts app-loader emits `"componentPreview":{` + `"active":true`
- [x] Existing "disables preview mode by default" test continues to pass (playground reads `.active`)
- [ ] Manual: run playground, verify `Preview Mode: Disabled` shown by default
- [ ] Manual: hit `/nuxt-component-preview/app-loader.js` and check the emitted JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
