### PR TITLE
refactor\!: Unify public runtime config under componentPreview namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,15 @@ export default defineNuxtConfig({
       overrides: {
         TestButton: { name: 'Custom Button', description: 'A button', category: 'Forms', status: 'experimental' }
       }
-    }
+    },
+
+    // Client-side `$fetch` path prefixes resolved against `app.cdnURL`
+    // instead of the embedding document's origin. See below.
+    cdnFetchPaths: [
+      '/nuxt-component-preview/',
+      '/api/_nuxt_icon/',
+      '/_i18n/',
+    ]
   }
 })
 ```
@@ -197,6 +205,10 @@ Filter the component index by directory path patterns. Works for both app-level 
 - `exclude.directories`: exclude components in these directories
 
 Both can be combined — e.g., include `Canvas` but exclude `Canvas/Internal`.
+
+#### `cdnFetchPaths`
+
+Client-side `$fetch` requests matching one of these path prefixes (via `startsWith`) are rewritten to use `app.cdnURL` as the base URL instead of resolving against the embedding document's origin. No-op when `app.cdnURL` is unset or the array is empty. Modules calling `$fetch.native` bypass ofetch and are not affected.
 
 ### Component Metadata
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ Both can be combined — e.g., include `Canvas` but exclude `Canvas/Internal`.
 
 #### `cdnFetchPaths`
 
-Client-side `$fetch` requests matching one of these path prefixes (via `startsWith`) are rewritten to use `app.cdnURL` as the base URL instead of resolving against the embedding document's origin. No-op when `app.cdnURL` is unset or the array is empty. Modules calling `$fetch.native` bypass ofetch and are not affected.
+A `$fetch` override **for component previews**. During a preview the Nuxt app runs inside an embedder document (e.g. a Drupal admin page), so relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or `@nuxt/icon` hit the embedder instead of Nitro. This plugin rewrites requests starting with one of the configured prefixes to use `app.cdnURL` (the Nuxt origin) as base URL.
+
+Defaults to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`. Set to `[]` to disable. `$fetch.native` callers bypass ofetch and are not intercepted.
 
 ### Component Metadata
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add the `<ComponentPreviewArea />` to your `app.vue` so previews render when pre
 
 ```vue
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview?.active" />
   <NuxtPage v-else />
 </template>
 ```

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview?.active" />
   <NuxtPage v-else />
 </template>
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -73,7 +73,7 @@
 
     <div style="margin: 2rem 0;">
       <h2>Module Status</h2>
-      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreview ? 'Enabled' : 'Disabled' }}</p>
+      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreview?.active ? 'Enabled' : 'Disabled' }}</p>
       <p>Preview mode should be disabled in normal app usage and only enabled when explicitly configured.</p>
     </div>
   </div>

--- a/playground/public/preview-test.html
+++ b/playground/public/preview-test.html
@@ -50,7 +50,7 @@
     window.__NUXT__ = {};
     window.__NUXT__.config = {
       public: {
-        componentPreview: true
+        componentPreview: { active: true }
       },
       app: {
         baseURL: "/",

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,21 +29,9 @@ export interface ModuleOptions {
     }>
   }
   /**
-   * Client-side `$fetch` path prefixes that should be resolved against
-   * `config.app.cdnURL` (the Nuxt app's own origin) instead of the
-   * embedding document's origin.
-   *
-   * Needed only for deployments where the Nuxt app is embedded
-   * cross-origin (micro-frontend, component preview): a module using
-   * plain `$fetch('/api/foo')` on the client otherwise resolves that
-   * relative URL against the embedder's origin.
-   *
-   * Each entry is matched with `startsWith` against the request URL.
-   * Set to an empty array to disable the interceptor entirely. Ignored
-   * when `config.app.cdnURL` is not configured (standalone Nuxt).
-   *
-   * Defaults cover the common Nitro-route-owning modules:
-   *   `/nuxt-component-preview/`, `/api/_nuxt_icon/`, `/_i18n/`
+   * Client-side `$fetch` path prefixes resolved against `app.cdnURL`
+   * instead of the document origin. Matched with `startsWith`. Empty
+   * array disables the interceptor; ignored when `app.cdnURL` is unset.
    */
   cdnFetchPaths?: string[]
 }
@@ -112,16 +100,8 @@ export default defineNuxtModule<ModuleOptions>({
       mode: 'client',
     })
 
-    // Expose cdnFetchPaths to the client plugin via public runtime config
-    // (so callers can override it via nuxt.config without rebuilding) and
-    // register the plugin that rewrites matching $fetch requests to use
-    // `app.cdnURL` as the base URL.
-    //
-    // Note: we deliberately use a dedicated `nuxtComponentPreview` key
-    // instead of the module's own `componentPreview` configKey namespace
-    // — that key is already treated as a boolean preview-mode switch
-    // elsewhere (see `plugin.client.ts`, `playground/app.vue`) and wrapping
-    // it in an object would flip the switch on for every consumer.
+    // Dedicated `nuxtComponentPreview` runtime key — `componentPreview`
+    // is a boolean preview-mode switch used elsewhere.
     const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>
     const existingNuxtComponentPreview = (publicConfig.nuxtComponentPreview as Record<string, unknown>) ?? {}
     publicConfig.nuxtComponentPreview = {

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,6 +28,24 @@ export interface ModuleOptions {
       status?: 'experimental' | 'stable' | 'deprecated' | 'obsolete'
     }>
   }
+  /**
+   * Client-side `$fetch` path prefixes that should be resolved against
+   * `config.app.cdnURL` (the Nuxt app's own origin) instead of the
+   * embedding document's origin.
+   *
+   * Needed only for deployments where the Nuxt app is embedded
+   * cross-origin (micro-frontend, component preview): a module using
+   * plain `$fetch('/api/foo')` on the client otherwise resolves that
+   * relative URL against the embedder's origin.
+   *
+   * Each entry is matched with `startsWith` against the request URL.
+   * Set to an empty array to disable the interceptor entirely. Ignored
+   * when `config.app.cdnURL` is not configured (standalone Nuxt).
+   *
+   * Defaults cover the common Nitro-route-owning modules:
+   *   `/nuxt-component-preview/`, `/api/_nuxt_icon/`, `/_i18n/`
+   */
+  cdnFetchPaths?: string[]
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -50,6 +68,11 @@ export default defineNuxtModule<ModuleOptions>({
       },
       overrides: {},
     },
+    cdnFetchPaths: [
+      '/nuxt-component-preview/',
+      '/api/_nuxt_icon/',
+      '/_i18n/',
+    ],
   },
   setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
@@ -86,6 +109,21 @@ export default defineNuxtModule<ModuleOptions>({
     // Add the client-side plugin for component preview functionality
     addPlugin({
       src: resolver.resolve('./runtime/plugin.client'),
+      mode: 'client',
+    })
+
+    // Expose cdnFetchPaths to the client plugin via public runtime config
+    // (so callers can override it via nuxt.config without rebuilding) and
+    // register the plugin that rewrites matching $fetch requests to use
+    // `app.cdnURL` as the base URL.
+    const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>
+    const existingComponentPreview = (publicConfig.componentPreview as Record<string, unknown>) ?? {}
+    publicConfig.componentPreview = {
+      ...existingComponentPreview,
+      cdnFetchPaths: options.cdnFetchPaths ?? [],
+    }
+    addPlugin({
+      src: resolver.resolve('./runtime/plugins/cdn-fetch-paths.client'),
       mode: 'client',
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -103,12 +103,13 @@ export default defineNuxtModule<ModuleOptions>({
       mode: 'client',
     })
 
-    // Dedicated `nuxtComponentPreview` runtime key — `componentPreview`
-    // is a boolean preview-mode switch used elsewhere.
+    // Runtime options live under `public.componentPreview` alongside the
+    // `active` flag the SSR app-loader sets when serving a preview. Single
+    // namespace aligned with the module's configKey.
     const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>
-    const existingNuxtComponentPreview = (publicConfig.nuxtComponentPreview as Record<string, unknown>) ?? {}
-    publicConfig.nuxtComponentPreview = {
-      ...existingNuxtComponentPreview,
+    const existingComponentPreview = (publicConfig.componentPreview as Record<string, unknown>) ?? {}
+    publicConfig.componentPreview = {
+      ...existingComponentPreview,
       cdnFetchPaths: options.cdnFetchPaths ?? [],
     }
     addPlugin({

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,9 +29,12 @@ export interface ModuleOptions {
     }>
   }
   /**
-   * Client-side `$fetch` path prefixes resolved against `app.cdnURL`
-   * instead of the document origin. Matched with `startsWith`. Empty
-   * array disables the interceptor; ignored when `app.cdnURL` is unset.
+   * Path prefixes for the component-preview `$fetch` override. Matching
+   * client-side `$fetch` requests are rerouted from the embedder's
+   * origin to `app.cdnURL` (the Nuxt origin). Active only when
+   * component preview is active. Matched with `startsWith`. Defaults
+   * to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`;
+   * set to `[]` to disable.
    */
   cdnFetchPaths?: string[]
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -116,10 +116,16 @@ export default defineNuxtModule<ModuleOptions>({
     // (so callers can override it via nuxt.config without rebuilding) and
     // register the plugin that rewrites matching $fetch requests to use
     // `app.cdnURL` as the base URL.
+    //
+    // Note: we deliberately use a dedicated `nuxtComponentPreview` key
+    // instead of the module's own `componentPreview` configKey namespace
+    // — that key is already treated as a boolean preview-mode switch
+    // elsewhere (see `plugin.client.ts`, `playground/app.vue`) and wrapping
+    // it in an object would flip the switch on for every consumer.
     const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>
-    const existingComponentPreview = (publicConfig.componentPreview as Record<string, unknown>) ?? {}
-    publicConfig.componentPreview = {
-      ...existingComponentPreview,
+    const existingNuxtComponentPreview = (publicConfig.nuxtComponentPreview as Record<string, unknown>) ?? {}
+    publicConfig.nuxtComponentPreview = {
+      ...existingNuxtComponentPreview,
       cdnFetchPaths: options.cdnFetchPaths ?? [],
     }
     addPlugin({

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,9 +1,12 @@
 import { defineNuxtPlugin, useState, useRuntimeConfig, onNuxtReady, nextTick } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  // Only activate when preview mode is enabled
+  // Only activate when preview mode is active (SSR app-loader sets
+  // public.componentPreview.active = true; on a regular Nuxt page it is
+  // absent).
   const config = useRuntimeConfig()
-  if (!config.public.componentPreview) {
+  const componentPreview = config.public.componentPreview as { active?: boolean } | undefined
+  if (!componentPreview?.active) {
     return
   }
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -31,15 +31,19 @@ export default defineNuxtPlugin({
   name: 'nuxt-component-preview:cdn-fetch-paths',
   enforce: 'pre',
   setup() {
-    if (!import.meta.client) return
-
+    // No `import.meta.client` guard: the plugin is registered with
+    // `mode: 'client'` in `src/module.ts` and the filename ends in
+    // `.client.ts`, so Nuxt already ensures this code only ships to the
+    // client. An inline guard would additionally short-circuit in unit
+    // tests running under @nuxt/test-utils' SSR-style env where
+    // `import.meta.client` is falsy.
     const config = useRuntimeConfig()
     const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
     if (!cdnURL) return
 
     const paths
-      = (config.public as { componentPreview?: { cdnFetchPaths?: string[] } })
-        .componentPreview?.cdnFetchPaths ?? []
+      = (config.public as { nuxtComponentPreview?: { cdnFetchPaths?: string[] } })
+        .nuxtComponentPreview?.cdnFetchPaths ?? []
     if (!paths.length) return
 
     const original = globalThis.$fetch

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -36,6 +36,8 @@ export default defineNuxtPlugin({
     globalThis.$fetch = original.create({
       onRequest({ request, options }) {
         if (typeof request !== 'string' || !request.startsWith('/')) return
+        // Respect a caller- or upstream-interceptor-provided baseURL.
+        if (options.baseURL) return
         if (!paths.some(prefix => request.startsWith(prefix))) return
         options.baseURL = cdnURL
       },

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -9,8 +9,9 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
  * plugin wraps `globalThis.$fetch` and rewrites requests matching a
  * configured `cdnFetchPaths` prefix to use `app.cdnURL` as base URL.
  *
- * Gated on `config.public.componentPreview` so regular Nuxt pages are
- * untouched (their document origin is already the Nuxt origin).
+ * Gated on `config.public.componentPreview.active` so regular Nuxt
+ * pages are untouched (their document origin is already the Nuxt
+ * origin).
  *
  * `$fetch.native` callers bypass ofetch and are not intercepted.
  */
@@ -19,15 +20,15 @@ export default defineNuxtPlugin({
   enforce: 'pre',
   setup() {
     const config = useRuntimeConfig()
+    const componentPreview = config.public.componentPreview as
+      { active?: boolean, cdnFetchPaths?: string[] } | undefined
     // Only active when component preview is active.
-    if (!config.public.componentPreview) return
+    if (!componentPreview?.active) return
 
     const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
     if (!cdnURL) return
 
-    const paths
-      = (config.public as { nuxtComponentPreview?: { cdnFetchPaths?: string[] } })
-        .nuxtComponentPreview?.cdnFetchPaths ?? []
+    const paths = componentPreview.cdnFetchPaths ?? []
     if (!paths.length) return
 
     const original = globalThis.$fetch

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,42 +1,14 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
- * Reroute `$fetch` calls to specific path prefixes so they hit the Nuxt
- * app's own origin (`config.app.cdnURL`) instead of the embedding
- * document's origin.
- *
- * Why: Nuxt's chunk loader already respects `app.cdnURL` for `/_nuxt/*`
- * asset loads, but plain `$fetch('/...')` calls in third-party modules
- * (for example `@nuxtjs/i18n`'s `messages.json` loader, or any module
- * that hits its own Nitro server routes) go straight to `fetch` with a
- * relative URL. In a component-preview deployment the embedding
- * document lives on a different origin than the Nuxt app, so those
- * relative URLs resolve against the embedder — not the Nuxt app — and
- * the fetch fails.
- *
- * This plugin installs an ofetch `onRequest` hook that rewrites `$fetch`
- * requests whose URL starts with one of the configured path prefixes to
- * use `app.cdnURL` as the base URL. Untouched when:
- *   - `app.cdnURL` is empty (standalone Nuxt deployment)
- *   - the configured path list is empty (opted out)
- *   - the request URL is already absolute
- *   - the request path doesn't match any configured prefix
- *
- * Limitation: the hook operates at the ofetch layer. Modules that use
- * `$fetch.native` (the raw platform `fetch`) bypass ofetch entirely and
- * therefore bypass this interceptor too — those modules need their own
- * cdnURL handling at the call site.
+ * Wraps `globalThis.$fetch` so requests whose path starts with a
+ * configured `cdnFetchPaths` prefix use `app.cdnURL` as the base URL.
+ * Modules using `$fetch.native` bypass ofetch and are not intercepted.
  */
 export default defineNuxtPlugin({
   name: 'nuxt-component-preview:cdn-fetch-paths',
   enforce: 'pre',
   setup() {
-    // No `import.meta.client` guard: the plugin is registered with
-    // `mode: 'client'` in `src/module.ts` and the filename ends in
-    // `.client.ts`, so Nuxt already ensures this code only ships to the
-    // client. An inline guard would additionally short-circuit in unit
-    // tests running under @nuxt/test-utils' SSR-style env where
-    // `import.meta.client` is falsy.
     const config = useRuntimeConfig()
     const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
     if (!cdnURL) return
@@ -53,8 +25,6 @@ export default defineNuxtPlugin({
       onRequest({ request, options }) {
         if (typeof request !== 'string' || !request.startsWith('/')) return
         if (!paths.some(prefix => request.startsWith(prefix))) return
-        // ofetch ignores `baseURL` for absolute URLs; we've guarded for
-        // that above, so the resolved URL becomes `${cdnURL}${request}`.
         options.baseURL = cdnURL
       },
     })

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,15 +1,27 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
- * Wraps `globalThis.$fetch` so requests whose path starts with a
- * configured `cdnFetchPaths` prefix use `app.cdnURL` as the base URL.
- * Modules using `$fetch.native` bypass ofetch and are not intercepted.
+ * `$fetch` override for component previews.
+ *
+ * In a preview the Nuxt app runs inside an embedder document, so
+ * relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or
+ * `@nuxt/icon` resolve against the embedder instead of Nitro. This
+ * plugin wraps `globalThis.$fetch` and rewrites requests matching a
+ * configured `cdnFetchPaths` prefix to use `app.cdnURL` as base URL.
+ *
+ * Gated on `config.public.componentPreview` so regular Nuxt pages are
+ * untouched (their document origin is already the Nuxt origin).
+ *
+ * `$fetch.native` callers bypass ofetch and are not intercepted.
  */
 export default defineNuxtPlugin({
   name: 'nuxt-component-preview:cdn-fetch-paths',
   enforce: 'pre',
   setup() {
     const config = useRuntimeConfig()
+    // Only active when component preview is active.
+    if (!config.public.componentPreview) return
+
     const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
     if (!cdnURL) return
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,0 +1,58 @@
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
+
+/**
+ * Reroute `$fetch` calls to specific path prefixes so they hit the Nuxt
+ * app's own origin (`config.app.cdnURL`) instead of the embedding
+ * document's origin.
+ *
+ * Why: Nuxt's chunk loader already respects `app.cdnURL` for `/_nuxt/*`
+ * asset loads, but plain `$fetch('/...')` calls in third-party modules
+ * (for example `@nuxtjs/i18n`'s `messages.json` loader, or any module
+ * that hits its own Nitro server routes) go straight to `fetch` with a
+ * relative URL. In a component-preview deployment the embedding
+ * document lives on a different origin than the Nuxt app, so those
+ * relative URLs resolve against the embedder — not the Nuxt app — and
+ * the fetch fails.
+ *
+ * This plugin installs an ofetch `onRequest` hook that rewrites `$fetch`
+ * requests whose URL starts with one of the configured path prefixes to
+ * use `app.cdnURL` as the base URL. Untouched when:
+ *   - `app.cdnURL` is empty (standalone Nuxt deployment)
+ *   - the configured path list is empty (opted out)
+ *   - the request URL is already absolute
+ *   - the request path doesn't match any configured prefix
+ *
+ * Limitation: the hook operates at the ofetch layer. Modules that use
+ * `$fetch.native` (the raw platform `fetch`) bypass ofetch entirely and
+ * therefore bypass this interceptor too — those modules need their own
+ * cdnURL handling at the call site.
+ */
+export default defineNuxtPlugin({
+  name: 'nuxt-component-preview:cdn-fetch-paths',
+  enforce: 'pre',
+  setup() {
+    if (!import.meta.client) return
+
+    const config = useRuntimeConfig()
+    const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
+    if (!cdnURL) return
+
+    const paths
+      = (config.public as { componentPreview?: { cdnFetchPaths?: string[] } })
+        .componentPreview?.cdnFetchPaths ?? []
+    if (!paths.length) return
+
+    const original = globalThis.$fetch
+    if (!original) return
+
+    globalThis.$fetch = original.create({
+      onRequest({ request, options }) {
+        if (typeof request !== 'string' || !request.startsWith('/')) return
+        if (!paths.some(prefix => request.startsWith(prefix))) return
+        // ofetch ignores `baseURL` for absolute URLs; we've guarded for
+        // that above, so the resolved URL becomes `${cdnURL}${request}`.
+        options.baseURL = cdnURL
+      },
+    })
+  },
+})

--- a/src/runtime/router.options.ts
+++ b/src/runtime/router.options.ts
@@ -5,8 +5,8 @@ export default <RouterConfig>{
   // Only change history mode on client when preview mode is enabled
   history: (base) => {
     if (import.meta.client && typeof window !== 'undefined') {
-      const previewMode = useNuxtApp().payload.config?.public?.componentPreview
-      if (previewMode) {
+      const componentPreview = useNuxtApp().payload.config?.public?.componentPreview as { active?: boolean } | undefined
+      if (componentPreview?.active) {
         console.log('[Component Preview] Using memory history')
         return createMemoryHistory(base)
       }

--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -24,11 +24,16 @@ export default defineEventHandler((event) => {
       : `${requestURL.protocol}//${requestURL.host}`
   }
 
-  // Serialize public config (with componentPreview enabled)
-  // Only include what's needed for the client
+  // Serialize public config and flag the preview as active. Merges
+  // `active: true` into the existing `componentPreview` object rather than
+  // replacing it, so module options (cdnFetchPaths, etc.) survive.
+  const existingComponentPreview = (config.public.componentPreview as Record<string, unknown>) ?? {}
   const publicConfig = {
     ...config.public,
-    componentPreview: true,
+    componentPreview: {
+      ...existingComponentPreview,
+      active: true,
+    },
   }
   const publicConfigStr = JSON.stringify(publicConfig)
   const entryCssPathsStr = JSON.stringify(entryCssPaths || [])

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,7 +27,10 @@ describe('nuxt-component-preview module', async () => {
     })
     expect(typeof script).toBe('string')
     expect(script).toContain('function initNuxt()')
-    expect(script).toContain('componentPreview')
+    // Activates preview mode via `componentPreview.active = true` (object
+    // shape, merged with any build-time componentPreview public config).
+    expect(script).toContain('"componentPreview":{')
+    expect(script).toContain('"active":true')
   })
 
   it('component index includes subfolder components with folder-prefixed names', async () => {

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -15,7 +15,7 @@ type OnRequestHook = (ctx: { request: string, options: { baseURL?: string } }) =
 const state: {
   runtimeConfig: {
     app: { cdnURL?: string }
-    public: { componentPreview?: { cdnFetchPaths?: string[] } }
+    public: { nuxtComponentPreview?: { cdnFetchPaths?: string[] } }
   }
   capturedOnRequest: OnRequestHook | null
 } = {
@@ -61,16 +61,17 @@ function simulateRequest(hook: OnRequestHook, request: string): string | undefin
 
 describe('cdnFetchPaths client plugin', () => {
   beforeEach(() => {
-    // Pretend we're on the client so the `import.meta.client` guard doesn't
-    // short-circuit the plugin. Vitest's default environment already has
-    // `window`, so `import.meta.client` is truthy here.
+    // Reset to an empty runtime config before each test; the plugin's
+    // client-only restriction is enforced at the Nuxt module level
+    // (`mode: 'client'` + `.client.ts` suffix), not at runtime, so no env
+    // stubbing is needed here.
     state.runtimeConfig = { app: {}, public: {} }
   })
 
   it('is a no-op when cdnURL is not set', async () => {
     state.runtimeConfig = {
       app: {},
-      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
     // Plugin returns early → no wrapper installed, no hook captured.
@@ -80,13 +81,13 @@ describe('cdnFetchPaths client plugin', () => {
   it('is a no-op when cdnFetchPaths is empty', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: { cdnFetchPaths: [] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: [] } },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
   })
 
-  it('is a no-op when componentPreview.cdnFetchPaths is missing', async () => {
+  it('is a no-op when nuxtComponentPreview.cdnFetchPaths is missing', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {},
@@ -98,7 +99,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('applies cdnURL as baseURL for matching path prefixes', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] } },
     }
     const hook = await runPluginSetup()
     expect(hook).not.toBeNull()
@@ -112,7 +113,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('strips a trailing slash from cdnURL to avoid `https://origin//api`', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com/' },
-      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
@@ -122,7 +123,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('leaves non-matching relative requests untouched', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
     // `/api/drupal-ce/…` is a Drupal-CE route served by the embedder —
@@ -135,7 +136,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('leaves absolute URLs untouched (ofetch ignores baseURL for those, but we also early-return)', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, 'https://somewhere.else/api/_nuxt_icon/ph.json'))
@@ -145,7 +146,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('matches with startsWith — custom prefixes can be added', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] } },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] } },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, '/api/my-custom-route/foo')).toBe('https://app.example.com')

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Exercises the `cdnFetchPaths` client plugin introduced to re-route
+ * client-side `$fetch` calls to the Nuxt app origin (`config.app.cdnURL`)
+ * instead of the embedding document's origin.
+ *
+ * Unit-style test: the plugin is imported directly with `#imports` and
+ * the global `$fetch` mocked, so we can capture what `options.baseURL`
+ * the plugin's `onRequest` hook applies to a given request path. No
+ * playground Nuxt instance needed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type OnRequestHook = (ctx: { request: string, options: { baseURL?: string } }) => void
+
+const state: {
+  runtimeConfig: {
+    app: { cdnURL?: string }
+    public: { componentPreview?: { cdnFetchPaths?: string[] } }
+  }
+  capturedOnRequest: OnRequestHook | null
+} = {
+  runtimeConfig: { app: {}, public: {} },
+  capturedOnRequest: null,
+}
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (opts: unknown) => opts,
+  useRuntimeConfig: () => state.runtimeConfig,
+}))
+
+/**
+ * Minimal $fetch mock whose `.create()` captures the `onRequest` hook
+ * passed by the plugin, so tests can call it directly and observe what
+ * `options.baseURL` it sets.
+ */
+function installMockFetch(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).$fetch = {
+    create(opts: { onRequest: OnRequestHook }) {
+      state.capturedOnRequest = opts.onRequest
+      return (globalThis as unknown as { $fetch: unknown }).$fetch
+    },
+  }
+}
+
+async function runPluginSetup(): Promise<OnRequestHook | null> {
+  state.capturedOnRequest = null
+  vi.resetModules()
+  installMockFetch()
+  const mod = await import('../src/runtime/plugins/cdn-fetch-paths.client')
+  const plugin = (mod as { default: { setup: () => void | Promise<void> } }).default
+  await plugin.setup()
+  return state.capturedOnRequest
+}
+
+function simulateRequest(hook: OnRequestHook, request: string): string | undefined {
+  const options: { baseURL?: string } = {}
+  hook({ request, options })
+  return options.baseURL
+}
+
+describe('cdnFetchPaths client plugin', () => {
+  beforeEach(() => {
+    // Pretend we're on the client so the `import.meta.client` guard doesn't
+    // short-circuit the plugin. Vitest's default environment already has
+    // `window`, so `import.meta.client` is truthy here.
+    state.runtimeConfig = { app: {}, public: {} }
+  })
+
+  it('is a no-op when cdnURL is not set', async () => {
+    state.runtimeConfig = {
+      app: {},
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+    }
+    const hook = await runPluginSetup()
+    // Plugin returns early → no wrapper installed, no hook captured.
+    expect(hook).toBeNull()
+  })
+
+  it('is a no-op when cdnFetchPaths is empty', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { componentPreview: { cdnFetchPaths: [] } },
+    }
+    const hook = await runPluginSetup()
+    expect(hook).toBeNull()
+  })
+
+  it('is a no-op when componentPreview.cdnFetchPaths is missing', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: {},
+    }
+    const hook = await runPluginSetup()
+    expect(hook).toBeNull()
+  })
+
+  it('applies cdnURL as baseURL for matching path prefixes', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] } },
+    }
+    const hook = await runPluginSetup()
+    expect(hook).not.toBeNull()
+
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json?icons=home'))
+      .toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/_i18n/abc123/en/messages.json'))
+      .toBe('https://app.example.com')
+  })
+
+  it('strips a trailing slash from cdnURL to avoid `https://origin//api`', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com/' },
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+    }
+    const hook = await runPluginSetup()
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
+      .toBe('https://app.example.com')
+  })
+
+  it('leaves non-matching relative requests untouched', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+    }
+    const hook = await runPluginSetup()
+    // `/api/drupal-ce/…` is a Drupal-CE route served by the embedder —
+    // must NOT be rewritten to the Nuxt origin.
+    expect(simulateRequest(hook!, '/api/drupal-ce/node/42')).toBeUndefined()
+    // Root-level `/favicon.ico` likewise.
+    expect(simulateRequest(hook!, '/favicon.ico')).toBeUndefined()
+  })
+
+  it('leaves absolute URLs untouched (ofetch ignores baseURL for those, but we also early-return)', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+    }
+    const hook = await runPluginSetup()
+    expect(simulateRequest(hook!, 'https://somewhere.else/api/_nuxt_icon/ph.json'))
+      .toBeUndefined()
+  })
+
+  it('matches with startsWith — custom prefixes can be added', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { componentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] } },
+    }
+    const hook = await runPluginSetup()
+    expect(simulateRequest(hook!, '/api/my-custom-route/foo')).toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/api/other/foo')).toBeUndefined()
+  })
+})

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -12,8 +12,7 @@ const state: {
   runtimeConfig: {
     app: { cdnURL?: string }
     public: {
-      componentPreview?: boolean
-      nuxtComponentPreview?: { cdnFetchPaths?: string[] }
+      componentPreview?: { active?: boolean, cdnFetchPaths?: string[] }
     }
   }
   capturedOnRequest: OnRequestHook | null
@@ -61,7 +60,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('is a no-op when component preview is not active', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: { componentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
@@ -71,8 +70,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: {},
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -83,18 +81,17 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: [] },
+        componentPreview: { active: true, cdnFetchPaths: [] },
       },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
   })
 
-  it('is a no-op when nuxtComponentPreview.cdnFetchPaths is missing', async () => {
+  it('is a no-op when cdnFetchPaths is missing', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { componentPreview: true },
+      public: { componentPreview: { active: true } },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
@@ -104,8 +101,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -121,8 +117,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com/' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -134,8 +129,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -147,8 +141,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -160,8 +153,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/_nuxt_icon/'] },
       },
     }
     const hook = await runPluginSetup()
@@ -175,8 +167,7 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
-        componentPreview: true,
-        nuxtComponentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] },
+        componentPreview: { active: true, cdnFetchPaths: ['/api/my-custom-route/'] },
       },
     }
     const hook = await runPluginSetup()

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -156,6 +156,21 @@ describe('cdnFetchPaths client plugin', () => {
       .toBeUndefined()
   })
 
+  it('respects a caller-provided options.baseURL', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
+    }
+    const hook = await runPluginSetup()
+    // A matching path that already has an explicit baseURL should be left alone.
+    const options: { baseURL?: string } = { baseURL: 'https://explicit.example' }
+    hook!({ request: '/api/_nuxt_icon/ph.json', options })
+    expect(options.baseURL).toBe('https://explicit.example')
+  })
+
   it('matches with startsWith — custom prefixes can be added', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -1,14 +1,7 @@
 /**
- * Exercises the `cdnFetchPaths` client plugin introduced to re-route
- * client-side `$fetch` calls to the Nuxt app origin (`config.app.cdnURL`)
- * instead of the embedding document's origin.
- *
- * Unit-style test: we stub `useRuntimeConfig` via `mockNuxtImport` (the
- * Nuxt test-utils equivalent of `vi.mock('#imports')` — plain vi.mock
- * does NOT intercept Nuxt's virtual module) and capture the `onRequest`
- * hook passed to `$fetch.create` so we can invoke it directly and
- * observe what `options.baseURL` the plugin applies to a given request
- * path. No playground Nuxt instance needed.
+ * Unit tests for the `cdnFetchPaths` client plugin. Stubs
+ * `useRuntimeConfig` via `mockNuxtImport` and captures the `onRequest`
+ * hook passed to `$fetch.create` to observe the resulting `baseURL`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
@@ -30,11 +23,6 @@ mockNuxtImport('useRuntimeConfig', () => {
   return () => state.runtimeConfig
 })
 
-/**
- * Minimal $fetch mock whose `.create()` captures the `onRequest` hook
- * passed by the plugin, so tests can call it directly and observe what
- * `options.baseURL` it sets.
- */
 function installMockFetch(): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).$fetch = {
@@ -50,9 +38,7 @@ async function runPluginSetup(): Promise<OnRequestHook | null> {
   vi.resetModules()
   installMockFetch()
   const mod = await import('../src/runtime/plugins/cdn-fetch-paths.client')
-  // defineNuxtPlugin returns the `setup` function itself, decorated with
-  // the other meta properties — so the default export is directly
-  // callable with (optional) nuxtApp as the argument.
+  // `defineNuxtPlugin({ setup })` returns the setup fn itself (decorated).
   const plugin = (mod as { default: (nuxtApp?: unknown) => void | Promise<void> }).default
   await plugin()
   return state.capturedOnRequest
@@ -66,10 +52,6 @@ function simulateRequest(hook: OnRequestHook, request: string): string | undefin
 
 describe('cdnFetchPaths client plugin', () => {
   beforeEach(() => {
-    // Reset to an empty runtime config before each test; the plugin's
-    // client-only restriction is enforced at the Nuxt module level
-    // (`mode: 'client'` + `.client.ts` suffix), not at runtime, so no env
-    // stubbing is needed here.
     state.runtimeConfig = { app: {}, public: {} }
   })
 
@@ -79,7 +61,6 @@ describe('cdnFetchPaths client plugin', () => {
       public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
-    // Plugin returns early → no wrapper installed, no hook captured.
     expect(hook).toBeNull()
   })
 
@@ -131,10 +112,7 @@ describe('cdnFetchPaths client plugin', () => {
       public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
     }
     const hook = await runPluginSetup()
-    // `/api/drupal-ce/…` is a Drupal-CE route served by the embedder —
-    // must NOT be rewritten to the Nuxt origin.
     expect(simulateRequest(hook!, '/api/drupal-ce/node/42')).toBeUndefined()
-    // Root-level `/favicon.ico` likewise.
     expect(simulateRequest(hook!, '/favicon.ico')).toBeUndefined()
   })
 

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -1,24 +1,17 @@
 /**
- * @vitest-environment happy-dom
- *
  * Exercises the `cdnFetchPaths` client plugin introduced to re-route
  * client-side `$fetch` calls to the Nuxt app origin (`config.app.cdnURL`)
  * instead of the embedding document's origin.
  *
- * Unit-style test: the plugin is imported directly with `#imports` and
- * the global `$fetch` mocked, so we can capture what `options.baseURL`
- * the plugin's `onRequest` hook applies to a given request path. No
- * playground Nuxt instance needed.
- *
- * The `@vitest-environment happy-dom` pragma opts this file out of the
- * repo-wide `environment: 'nuxt'` setting from `vitest.config.ts` —
- * under the Nuxt env, `#imports` resolves to the real Nuxt virtual
- * module and `vi.mock('#imports')` does NOT intercept it, so
- * `useRuntimeConfig()` returns the playground's empty config instead
- * of the per-test stub. happy-dom gives a plain vite module graph
- * where the mock works as written.
+ * Unit-style test: we stub `useRuntimeConfig` via `mockNuxtImport` (the
+ * Nuxt test-utils equivalent of `vi.mock('#imports')` — plain vi.mock
+ * does NOT intercept Nuxt's virtual module) and capture the `onRequest`
+ * hook passed to `$fetch.create` so we can invoke it directly and
+ * observe what `options.baseURL` the plugin applies to a given request
+ * path. No playground Nuxt instance needed.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 type OnRequestHook = (ctx: { request: string, options: { baseURL?: string } }) => void
 
@@ -33,10 +26,9 @@ const state: {
   capturedOnRequest: null,
 }
 
-vi.mock('#imports', () => ({
-  defineNuxtPlugin: (opts: unknown) => opts,
-  useRuntimeConfig: () => state.runtimeConfig,
-}))
+mockNuxtImport('useRuntimeConfig', () => {
+  return () => state.runtimeConfig
+})
 
 /**
  * Minimal $fetch mock whose `.create()` captures the `onRequest` hook
@@ -58,8 +50,11 @@ async function runPluginSetup(): Promise<OnRequestHook | null> {
   vi.resetModules()
   installMockFetch()
   const mod = await import('../src/runtime/plugins/cdn-fetch-paths.client')
-  const plugin = (mod as { default: { setup: () => void | Promise<void> } }).default
-  await plugin.setup()
+  // defineNuxtPlugin returns the `setup` function itself, decorated with
+  // the other meta properties — so the default export is directly
+  // callable with (optional) nuxtApp as the argument.
+  const plugin = (mod as { default: (nuxtApp?: unknown) => void | Promise<void> }).default
+  await plugin()
   return state.capturedOnRequest
 }
 

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -1,4 +1,6 @@
 /**
+ * @vitest-environment happy-dom
+ *
  * Exercises the `cdnFetchPaths` client plugin introduced to re-route
  * client-side `$fetch` calls to the Nuxt app origin (`config.app.cdnURL`)
  * instead of the embedding document's origin.
@@ -7,6 +9,14 @@
  * the global `$fetch` mocked, so we can capture what `options.baseURL`
  * the plugin's `onRequest` hook applies to a given request path. No
  * playground Nuxt instance needed.
+ *
+ * The `@vitest-environment happy-dom` pragma opts this file out of the
+ * repo-wide `environment: 'nuxt'` setting from `vitest.config.ts` —
+ * under the Nuxt env, `#imports` resolves to the real Nuxt virtual
+ * module and `vi.mock('#imports')` does NOT intercept it, so
+ * `useRuntimeConfig()` returns the playground's empty config instead
+ * of the per-test stub. happy-dom gives a plain vite module graph
+ * where the mock works as written.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -11,7 +11,10 @@ type OnRequestHook = (ctx: { request: string, options: { baseURL?: string } }) =
 const state: {
   runtimeConfig: {
     app: { cdnURL?: string }
-    public: { nuxtComponentPreview?: { cdnFetchPaths?: string[] } }
+    public: {
+      componentPreview?: boolean
+      nuxtComponentPreview?: { cdnFetchPaths?: string[] }
+    }
   }
   capturedOnRequest: OnRequestHook | null
 } = {
@@ -55,10 +58,22 @@ describe('cdnFetchPaths client plugin', () => {
     state.runtimeConfig = { app: {}, public: {} }
   })
 
+  it('is a no-op when component preview is not active', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+    }
+    const hook = await runPluginSetup()
+    expect(hook).toBeNull()
+  })
+
   it('is a no-op when cdnURL is not set', async () => {
     state.runtimeConfig = {
       app: {},
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
@@ -67,7 +82,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('is a no-op when cdnFetchPaths is empty', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: [] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: [] },
+      },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
@@ -76,7 +94,7 @@ describe('cdnFetchPaths client plugin', () => {
   it('is a no-op when nuxtComponentPreview.cdnFetchPaths is missing', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: {},
+      public: { componentPreview: true },
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
@@ -85,7 +103,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('applies cdnURL as baseURL for matching path prefixes', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/', '/_i18n/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(hook).not.toBeNull()
@@ -99,7 +120,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('strips a trailing slash from cdnURL to avoid `https://origin//api`', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com/' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
@@ -109,7 +133,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('leaves non-matching relative requests untouched', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, '/api/drupal-ce/node/42')).toBeUndefined()
@@ -119,7 +146,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('leaves absolute URLs untouched (ofetch ignores baseURL for those, but we also early-return)', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, 'https://somewhere.else/api/_nuxt_icon/ph.json'))
@@ -129,7 +159,10 @@ describe('cdnFetchPaths client plugin', () => {
   it('matches with startsWith — custom prefixes can be added', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
-      public: { nuxtComponentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] } },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/my-custom-route/'] },
+      },
     }
     const hook = await runPluginSetup()
     expect(simulateRequest(hook!, '/api/my-custom-route/foo')).toBe('https://app.example.com')


### PR DESCRIPTION
## Problem

Three related but conflicting names in the public config surface area:

| Where | Key | Was |
|---|---|---|
| `nuxt.config.ts` | `componentPreview` | user-facing module options (via `configKey: 'componentPreview'`) |
| `runtimeConfig.public.componentPreview` | **boolean** "preview mode active" flag set by the SSR app-loader | |
| `runtimeConfig.public.nuxtComponentPreview` | `{ cdnFetchPaths }` — parked here in #TBD because the boolean was squatting on the short name | |

## Fix

Single namespace, aligned with the module's `configKey`:

```ts
public.componentPreview: {
  active?: boolean        // set by SSR app-loader when serving a preview
  cdnFetchPaths?: string[]
  // ... future module runtime options
}
```

The SSR app-loader now **merges** `active: true` into the existing `componentPreview` object rather than overwriting it with a boolean, so runtime options survive.

Sites into `nuxt.config.ts` (`componentPreview: { ... }`) are unchanged.

## Breaking change

For any external code reading runtime config directly:

- `config.public.componentPreview` was a boolean, now an object. Readers must switch to `config.public.componentPreview?.active`.
- `config.public.nuxtComponentPreview` is removed. Move reads to `config.public.componentPreview`.

Internal call sites updated in this PR:
- `src/runtime/plugin.client.ts`
- `src/runtime/router.options.ts`
- `src/runtime/plugins/cdn-fetch-paths.client.ts`
- `src/runtime/server/api/app-loader.js.get.ts`
- `playground/app.vue`, `playground/pages/index.vue`, `playground/public/preview-test.html`
- README code example

## Tests

`test/cdn-fetch-paths.test.ts` reshaped to the new nested state. 10/10 pass locally.

## Stacking

Targets `feature/cdn-fetch-paths-interceptor` (#164). The `options.baseURL`-respect fix (`a002dde`) was added to #164 too.

Claude Code: refactor and PR generated with [Claude Code](https://claude.com/claude-code)