### PR TITLE
refactor: Make public.componentPreviewActive the primary preview-active flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add the `<ComponentPreviewArea />` to your `app.vue` so previews render when pre
 
 ```vue
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreviewActive" />
   <NuxtPage v-else />
 </template>
 ```

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreview" />
+  <ComponentPreviewArea v-if="useRuntimeConfig().public.componentPreviewActive" />
   <NuxtPage v-else />
 </template>
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -73,7 +73,7 @@
 
     <div style="margin: 2rem 0;">
       <h2>Module Status</h2>
-      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreview ? 'Enabled' : 'Disabled' }}</p>
+      <p><strong>Preview Mode:</strong> {{ $config.public.componentPreviewActive ? 'Enabled' : 'Disabled' }}</p>
       <p>Preview mode should be disabled in normal app usage and only enabled when explicitly configured.</p>
     </div>
   </div>

--- a/playground/public/preview-test.html
+++ b/playground/public/preview-test.html
@@ -50,7 +50,7 @@
     window.__NUXT__ = {};
     window.__NUXT__.config = {
       public: {
-        componentPreview: true
+        componentPreviewActive: true
       },
       app: {
         baseURL: "/",

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,9 +1,12 @@
 import { defineNuxtPlugin, useState, useRuntimeConfig, onNuxtReady, nextTick } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  // Only activate when preview mode is enabled
+  // Only activate when preview mode is enabled. Primary flag is
+  // `componentPreviewActive`; legacy `componentPreview === true` is also
+  // honoured so pre-migration consumers keep working.
   const config = useRuntimeConfig()
-  if (!config.public.componentPreview) {
+  const pub = config.public as { componentPreviewActive?: boolean, componentPreview?: unknown }
+  if (pub.componentPreviewActive !== true && pub.componentPreview !== true) {
     return
   }
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -9,7 +9,8 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
  * plugin wraps `globalThis.$fetch` and rewrites requests matching a
  * configured `cdnFetchPaths` prefix to use `app.cdnURL` as base URL.
  *
- * Gated on `config.public.componentPreview` so regular Nuxt pages are
+ * Gated on `config.public.componentPreviewActive` (with legacy fallback to
+ * `config.public.componentPreview === true`) so regular Nuxt pages are
  * untouched (their document origin is already the Nuxt origin).
  *
  * `$fetch.native` callers bypass ofetch and are not intercepted.
@@ -20,7 +21,8 @@ export default defineNuxtPlugin({
   setup() {
     const config = useRuntimeConfig()
     // Only active when component preview is active.
-    if (!config.public.componentPreview) return
+    const pub = config.public as { componentPreviewActive?: boolean, componentPreview?: unknown }
+    if (pub.componentPreviewActive !== true && pub.componentPreview !== true) return
 
     const cdnURL = config.app?.cdnURL?.replace(/\/$/, '') ?? ''
     if (!cdnURL) return

--- a/src/runtime/router.options.ts
+++ b/src/runtime/router.options.ts
@@ -5,8 +5,10 @@ export default <RouterConfig>{
   // Only change history mode on client when preview mode is enabled
   history: (base) => {
     if (import.meta.client && typeof window !== 'undefined') {
-      const previewMode = useNuxtApp().payload.config?.public?.componentPreview
-      if (previewMode) {
+      // Primary: componentPreviewActive. Legacy: componentPreview === true.
+      const pub = useNuxtApp().payload.config?.public as
+        { componentPreviewActive?: boolean, componentPreview?: unknown } | undefined
+      if (pub?.componentPreviewActive === true || pub?.componentPreview === true) {
         console.log('[Component Preview] Using memory history')
         return createMemoryHistory(base)
       }

--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -24,15 +24,12 @@ export default defineEventHandler((event) => {
       : `${requestURL.protocol}//${requestURL.host}`
   }
 
-  // Serialize public config and flag the preview as active. We set both
-  // `componentPreviewActive` (the new primary flag) and `componentPreview`
-  // (legacy boolean) so existing consumer code written against the old
-  // contract keeps working until callers migrate to
-  // `componentPreviewActive`.
+  // Serialize public config and flag the preview as active. We only set
+  // `componentPreviewActive` — `public.componentPreview` is left alone so
+  // users remain free to put their own object value there via runtimeConfig.
   const publicConfig = {
     ...config.public,
     componentPreviewActive: true,
-    componentPreview: true,
   }
   const publicConfigStr = JSON.stringify(publicConfig)
   const entryCssPathsStr = JSON.stringify(entryCssPaths || [])

--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -24,10 +24,16 @@ export default defineEventHandler((event) => {
       : `${requestURL.protocol}//${requestURL.host}`
   }
 
-  // Serialize public config and flag the preview as active. We only set
-  // `componentPreviewActive` — `public.componentPreview` is left alone so
-  // users remain free to put their own object value there via runtimeConfig.
+  // Serialize public config and flag the preview as active.
+  // - `componentPreviewActive: true` is always set — the new primary flag.
+  // - `componentPreview: true` is emitted as a BC default for legacy
+  //   consumer code that still reads `public.componentPreview` as a
+  //   boolean (e.g. kickstart's app.vue before it migrates). The spread
+  //   of `config.public` comes after, so if the user has populated
+  //   `componentPreview` in their runtimeConfig (e.g. as an object), that
+  //   value wins and is not clobbered.
   const publicConfig = {
+    componentPreview: true,
     ...config.public,
     componentPreviewActive: true,
   }

--- a/src/runtime/server/api/app-loader.js.get.ts
+++ b/src/runtime/server/api/app-loader.js.get.ts
@@ -24,10 +24,14 @@ export default defineEventHandler((event) => {
       : `${requestURL.protocol}//${requestURL.host}`
   }
 
-  // Serialize public config (with componentPreview enabled)
-  // Only include what's needed for the client
+  // Serialize public config and flag the preview as active. We set both
+  // `componentPreviewActive` (the new primary flag) and `componentPreview`
+  // (legacy boolean) so existing consumer code written against the old
+  // contract keeps working until callers migrate to
+  // `componentPreviewActive`.
   const publicConfig = {
     ...config.public,
+    componentPreviewActive: true,
     componentPreview: true,
   }
   const publicConfigStr = JSON.stringify(publicConfig)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,10 +27,12 @@ describe('nuxt-component-preview module', async () => {
     })
     expect(typeof script).toBe('string')
     expect(script).toContain('function initNuxt()')
-    // Sets the new primary flag only. `public.componentPreview` is left
-    // alone so users may put their own object value there via runtimeConfig.
+    // Emits the new primary flag always; defaults legacy `componentPreview`
+    // to `true` as a BC fallback for consumer code that still reads the
+    // old boolean. If the user populates `componentPreview` in their own
+    // runtimeConfig (e.g. as an object), that value overrides this default.
     expect(script).toContain('"componentPreviewActive":true')
-    expect(script).not.toContain('"componentPreview":true')
+    expect(script).toContain('"componentPreview":true')
   })
 
   it('component index includes subfolder components with folder-prefixed names', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,11 +27,10 @@ describe('nuxt-component-preview module', async () => {
     })
     expect(typeof script).toBe('string')
     expect(script).toContain('function initNuxt()')
-    // Sets the new primary flag and keeps the legacy boolean set for BC
-    // with existing `public.componentPreview` checks in kickstart
-    // (app.vue, middleware) until they migrate to componentPreviewActive.
+    // Sets the new primary flag only. `public.componentPreview` is left
+    // alone so users may put their own object value there via runtimeConfig.
     expect(script).toContain('"componentPreviewActive":true')
-    expect(script).toContain('"componentPreview":true')
+    expect(script).not.toContain('"componentPreview":true')
   })
 
   it('component index includes subfolder components with folder-prefixed names', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -27,7 +27,11 @@ describe('nuxt-component-preview module', async () => {
     })
     expect(typeof script).toBe('string')
     expect(script).toContain('function initNuxt()')
-    expect(script).toContain('componentPreview')
+    // Sets the new primary flag and keeps the legacy boolean set for BC
+    // with existing `public.componentPreview` checks in kickstart
+    // (app.vue, middleware) until they migrate to componentPreviewActive.
+    expect(script).toContain('"componentPreviewActive":true')
+    expect(script).toContain('"componentPreview":true')
   })
 
   it('component index includes subfolder components with folder-prefixed names', async () => {

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -13,6 +13,7 @@ const state: {
     app: { cdnURL?: string }
     public: {
       componentPreview?: boolean
+      componentPreviewActive?: boolean
       nuxtComponentPreview?: { cdnFetchPaths?: string[] }
     }
   }
@@ -65,6 +66,34 @@ describe('cdnFetchPaths client plugin', () => {
     }
     const hook = await runPluginSetup()
     expect(hook).toBeNull()
+  })
+
+  it('activates on componentPreviewActive: true (new primary flag)', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: {
+        componentPreviewActive: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
+    }
+    const hook = await runPluginSetup()
+    expect(hook).not.toBeNull()
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
+      .toBe('https://app.example.com')
+  })
+
+  it('activates on componentPreview: true (legacy boolean flag)', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
+    }
+    const hook = await runPluginSetup()
+    expect(hook).not.toBeNull()
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
+      .toBe('https://app.example.com')
   })
 
   it('is a no-op when cdnURL is not set', async () => {


### PR DESCRIPTION
## Problem

`public.componentPreview` does double duty: it's both the configKey namespace (user-facing `componentPreview: { cdnFetchPaths, componentIndex, ... }` in `nuxt.config`) and the runtime boolean flag the SSR app-loader sets (`componentPreview: true`). These collide — #164 had to park `cdnFetchPaths` under a separate `nuxtComponentPreview` key because the app-loader was overwriting the whole value.

## Fix (backwards compatible)

Introduce a dedicated **`public.componentPreviewActive`** boolean as the new primary preview-active flag. The app-loader now sets **both**:

```ts
public: {
  ...,
  componentPreviewActive: true,   // new primary
  componentPreview: true,         // legacy — kept for BC
}
```

Internal readers (`plugin.client.ts`, `router.options.ts`, `plugins/cdn-fetch-paths.client.ts`) check `componentPreviewActive === true` first and fall back to the legacy `componentPreview === true`. Docs, playground, and the preview-test fixture are moved onto the new name.

**Not changed in this PR:** `cdnFetchPaths` continues to live at `public.nuxtComponentPreview.cdnFetchPaths` (as shipped by #164). No touch to the module's `configKey` (`componentPreview`) either — user-facing config in `nuxt.config` is unchanged.

## Migration for downstream consumers

Prefer `public.componentPreviewActive` in new code:

```diff
- v-if="useRuntimeConfig().public.componentPreview"
+ v-if="useRuntimeConfig().public.componentPreviewActive"
```

Existing `public.componentPreview` boolean reads continue to work — the app-loader sets it alongside the new flag so nothing breaks. Kickstart's `app.vue` + preview-redirect middleware will be migrated in a separate follow-up PR after this lands.

## Tests

- `test/cdn-fetch-paths.test.ts`: new cases covering activation via both the new primary flag and the legacy boolean.
- `test/basic.test.ts`: asserts the app-loader JSON contains both `"componentPreviewActive":true` and `"componentPreview":true`.

Full suite passes locally (105/105).

## Supersedes

- #165 — same boolean→object idea from my earlier duplicate attempt; different direction (BC instead of breaking).
- #166 — did a breaking namespace-merge; this is the BC equivalent.

Claude Code: generated with [Claude Code](https://claude.com/claude-code)