### PR TITLE
improve: make cdnFetchPaths wrap $fetch.native also

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Both can be combined — e.g., include `Canvas` but exclude `Canvas/Internal`.
 
 A `$fetch` / `$fetch.native` override **for component previews**. During a preview the Nuxt app runs inside an embedder document (e.g. a Drupal admin page), so relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or `@nuxt/icon` hit the embedder instead of Nitro. This plugin rewrites matching requests to absolute URLs at `app.cdnURL`, covering both ofetch (`$fetch`) and raw-fetch (`$fetch.native`, used e.g. by `@nuxt/icon`) callers.
 
-Defaults to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`. Set to `[]` to disable. An explicit absolute (`http://` / `https://`) caller-provided `options.baseURL` is respected — only the Nuxt default (empty or `/`) is treated as "no caller override" and rewritten.
+Defaults to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`. Set to `[]` to disable. An explicit absolute (`http://` / `https://`) caller-provided `options.baseURL` is respected; only the Nuxt default (empty or `/`) is treated as "no caller override" and rewritten.
 
 ### Component Metadata
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ Both can be combined — e.g., include `Canvas` but exclude `Canvas/Internal`.
 
 #### `cdnFetchPaths`
 
-A `$fetch` override **for component previews**. During a preview the Nuxt app runs inside an embedder document (e.g. a Drupal admin page), so relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or `@nuxt/icon` hit the embedder instead of Nitro. This plugin rewrites requests starting with one of the configured prefixes to use `app.cdnURL` (the Nuxt origin) as base URL.
+A `$fetch` / `$fetch.native` override **for component previews**. During a preview the Nuxt app runs inside an embedder document (e.g. a Drupal admin page), so relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or `@nuxt/icon` hit the embedder instead of Nitro. This plugin rewrites matching requests to absolute URLs at `app.cdnURL`, covering both ofetch (`$fetch`) and raw-fetch (`$fetch.native`, used e.g. by `@nuxt/icon`) callers.
 
-Defaults to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`. Set to `[]` to disable. `$fetch.native` callers bypass ofetch and are not intercepted.
+Defaults to `['/nuxt-component-preview/', '/api/_nuxt_icon/', '/_i18n/']`. Set to `[]` to disable. An explicit absolute (`http://` / `https://`) caller-provided `options.baseURL` is respected — only the Nuxt default (empty or `/`) is treated as "no caller override" and rewritten.
 
 ### Component Metadata
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,26 +1,40 @@
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 /**
- * `$fetch` override for component previews.
+ * `$fetch` / `$fetch.native` override for component previews.
  *
  * In a preview the Nuxt app runs inside an embedder document, so
  * relative `$fetch('/...')` calls from modules like `@nuxtjs/i18n` or
  * `@nuxt/icon` resolve against the embedder instead of Nitro. This
- * plugin wraps `globalThis.$fetch` and rewrites requests matching a
- * configured `cdnFetchPaths` prefix to use `app.cdnURL` as base URL.
+ * plugin rewrites matching relative URLs to an absolute URL at
+ * `app.cdnURL`.
  *
- * Gated on `config.public.componentPreviewActive` (with legacy fallback to
- * `config.public.componentPreview === true`) so regular Nuxt pages are
- * untouched (their document origin is already the Nuxt origin).
+ * Covers two paths:
+ *  - `globalThis.$fetch` (ofetch): an `onRequest` hook that rewrites
+ *    `ctx.request` to an absolute URL. Making the URL absolute
+ *    sidesteps any baseURL merging (including the default baseURL that
+ *    Nuxt bakes into its global ofetch instance via
+ *    `$fetch.create({ baseURL })`, which would otherwise shadow the
+ *    rewrite if we only set `options.baseURL`).
+ *  - `globalThis.$fetch.native`: modules using the raw platform fetch
+ *    (e.g. `@nuxt/icon` via `Kf.setFetch($fetch.native)`) bypass ofetch
+ *    and any onRequest hook above. We rebind `.native` so callers
+ *    capturing it after our `enforce: 'pre'` runs get the rewriting
+ *    variant.
  *
- * `$fetch.native` callers bypass ofetch and are not intercepted.
+ * An explicit absolute (`http://` / `https://`) caller-provided
+ * `options.baseURL` is respected — we only rewrite when the effective
+ * baseURL is the Nuxt-default (empty or `/`).
+ *
+ * Gated on `config.public.componentPreviewActive` (with legacy fallback
+ * to `config.public.componentPreview === true`) so regular Nuxt pages
+ * are untouched.
  */
 export default defineNuxtPlugin({
   name: 'nuxt-component-preview:cdn-fetch-paths',
   enforce: 'pre',
   setup() {
     const config = useRuntimeConfig()
-    // Only active when component preview is active.
     const pub = config.public as { componentPreviewActive?: boolean, componentPreview?: unknown }
     if (pub.componentPreviewActive !== true && pub.componentPreview !== true) return
 
@@ -36,13 +50,31 @@ export default defineNuxtPlugin({
     if (!original) return
 
     globalThis.$fetch = original.create({
-      onRequest({ request, options }) {
-        if (typeof request !== 'string' || !request.startsWith('/')) return
-        // Respect a caller- or upstream-interceptor-provided baseURL.
-        if (options.baseURL) return
-        if (!paths.some(prefix => request.startsWith(prefix))) return
-        options.baseURL = cdnURL
+      onRequest(ctx) {
+        if (typeof ctx.request !== 'string' || !ctx.request.startsWith('/')) return
+        if (!paths.some(prefix => (ctx.request as string).startsWith(prefix))) return
+        // Respect an explicit absolute (http/https) baseURL — caller
+        // targeted an external origin deliberately. A Nuxt-default
+        // empty / "/" baseURL is not an override and still gets
+        // rewritten below.
+        const ob = ctx.options.baseURL
+        if (typeof ob === 'string' && /^https?:\/\//i.test(ob)) return
+        // Rewrite to an absolute URL so ofetch sidesteps any baseURL
+        // merging.
+        ctx.request = cdnURL + ctx.request
       },
     })
+
+    const originalNative = globalThis.$fetch.native
+    if (originalNative) {
+      globalThis.$fetch.native = function (input, init) {
+        if (typeof input === 'string' && input.startsWith('/')) {
+          if (paths.some(prefix => input.startsWith(prefix))) {
+            input = cdnURL + input
+          }
+        }
+        return originalNative.call(this, input, init)
+      }
+    }
   },
 })

--- a/test/cdn-fetch-paths.test.ts
+++ b/test/cdn-fetch-paths.test.ts
@@ -1,12 +1,17 @@
 /**
  * Unit tests for the `cdnFetchPaths` client plugin. Stubs
  * `useRuntimeConfig` via `mockNuxtImport` and captures the `onRequest`
- * hook passed to `$fetch.create` to observe the resulting `baseURL`.
+ * hook passed to `$fetch.create` to observe the rewritten request URL.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
-type OnRequestHook = (ctx: { request: string, options: { baseURL?: string } }) => void
+type FetchContext = {
+  request: string
+  options: { baseURL?: string }
+}
+type OnRequestHook = (ctx: FetchContext) => void
+type NativeFetch = (input: string, init?: { baseURL?: string }) => Promise<unknown>
 
 const state: {
   runtimeConfig: {
@@ -18,9 +23,11 @@ const state: {
     }
   }
   capturedOnRequest: OnRequestHook | null
+  nativeCalls: Array<{ input: string, init?: { baseURL?: string } }>
 } = {
   runtimeConfig: { app: {}, public: {} },
   capturedOnRequest: null,
+  nativeCalls: [],
 }
 
 mockNuxtImport('useRuntimeConfig', () => {
@@ -28,11 +35,22 @@ mockNuxtImport('useRuntimeConfig', () => {
 })
 
 function installMockFetch(): void {
+  state.nativeCalls = []
+  const originalNative: NativeFetch = async (input, init) => {
+    state.nativeCalls.push({ input, init })
+    return { ok: true }
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).$fetch = {
+    native: originalNative,
     create(opts: { onRequest: OnRequestHook }) {
       state.capturedOnRequest = opts.onRequest
-      return (globalThis as unknown as { $fetch: unknown }).$fetch
+      // Preserve the original `.native` on the returned instance so the
+      // plugin can wrap it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wrapped: any = (globalThis as unknown as { $fetch: unknown }).$fetch
+      wrapped.native = originalNative
+      return wrapped
     },
   }
 }
@@ -48,10 +66,14 @@ async function runPluginSetup(): Promise<OnRequestHook | null> {
   return state.capturedOnRequest
 }
 
-function simulateRequest(hook: OnRequestHook, request: string): string | undefined {
-  const options: { baseURL?: string } = {}
-  hook({ request, options })
-  return options.baseURL
+function simulateRequest(
+  hook: OnRequestHook,
+  request: string,
+  initialOptions: { baseURL?: string } = {},
+): FetchContext {
+  const ctx: FetchContext = { request, options: initialOptions }
+  hook(ctx)
+  return ctx
 }
 
 describe('cdnFetchPaths client plugin', () => {
@@ -78,8 +100,8 @@ describe('cdnFetchPaths client plugin', () => {
     }
     const hook = await runPluginSetup()
     expect(hook).not.toBeNull()
-    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
-      .toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json').request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json')
   })
 
   it('activates on componentPreview: true (legacy boolean flag)', async () => {
@@ -92,8 +114,8 @@ describe('cdnFetchPaths client plugin', () => {
     }
     const hook = await runPluginSetup()
     expect(hook).not.toBeNull()
-    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
-      .toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json').request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json')
   })
 
   it('is a no-op when cdnURL is not set', async () => {
@@ -129,7 +151,7 @@ describe('cdnFetchPaths client plugin', () => {
     expect(hook).toBeNull()
   })
 
-  it('applies cdnURL as baseURL for matching path prefixes', async () => {
+  it('rewrites matching relative requests to absolute URLs', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
@@ -140,10 +162,28 @@ describe('cdnFetchPaths client plugin', () => {
     const hook = await runPluginSetup()
     expect(hook).not.toBeNull()
 
-    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json?icons=home'))
-      .toBe('https://app.example.com')
-    expect(simulateRequest(hook!, '/_i18n/abc123/en/messages.json'))
-      .toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json?icons=home').request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json?icons=home')
+    expect(simulateRequest(hook!, '/_i18n/abc123/en/messages.json').request)
+      .toBe('https://app.example.com/_i18n/abc123/en/messages.json')
+  })
+
+  it('overrides a Nuxt-default baseURL (empty or "/")', async () => {
+    state.runtimeConfig = {
+      app: { cdnURL: 'https://app.example.com' },
+      public: {
+        componentPreview: true,
+        nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+      },
+    }
+    const hook = await runPluginSetup()
+    // Default baseURL of '/' is what Nuxt bakes into globalThis.$fetch.
+    // We still rewrite because only an absolute http(s) baseURL is
+    // treated as a caller override.
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json', { baseURL: '/' }).request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json')
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json', { baseURL: '' }).request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json')
   })
 
   it('strips a trailing slash from cdnURL to avoid `https://origin//api`', async () => {
@@ -155,8 +195,8 @@ describe('cdnFetchPaths client plugin', () => {
       },
     }
     const hook = await runPluginSetup()
-    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json'))
-      .toBe('https://app.example.com')
+    expect(simulateRequest(hook!, '/api/_nuxt_icon/ph.json').request)
+      .toBe('https://app.example.com/api/_nuxt_icon/ph.json')
   })
 
   it('leaves non-matching relative requests untouched', async () => {
@@ -168,11 +208,11 @@ describe('cdnFetchPaths client plugin', () => {
       },
     }
     const hook = await runPluginSetup()
-    expect(simulateRequest(hook!, '/api/drupal-ce/node/42')).toBeUndefined()
-    expect(simulateRequest(hook!, '/favicon.ico')).toBeUndefined()
+    expect(simulateRequest(hook!, '/api/drupal-ce/node/42').request).toBe('/api/drupal-ce/node/42')
+    expect(simulateRequest(hook!, '/favicon.ico').request).toBe('/favicon.ico')
   })
 
-  it('leaves absolute URLs untouched (ofetch ignores baseURL for those, but we also early-return)', async () => {
+  it('leaves absolute URLs untouched', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
@@ -181,11 +221,11 @@ describe('cdnFetchPaths client plugin', () => {
       },
     }
     const hook = await runPluginSetup()
-    expect(simulateRequest(hook!, 'https://somewhere.else/api/_nuxt_icon/ph.json'))
-      .toBeUndefined()
+    expect(simulateRequest(hook!, 'https://somewhere.else/api/_nuxt_icon/ph.json').request)
+      .toBe('https://somewhere.else/api/_nuxt_icon/ph.json')
   })
 
-  it('respects a caller-provided options.baseURL', async () => {
+  it('respects an explicit absolute caller-provided baseURL', async () => {
     state.runtimeConfig = {
       app: { cdnURL: 'https://app.example.com' },
       public: {
@@ -194,10 +234,11 @@ describe('cdnFetchPaths client plugin', () => {
       },
     }
     const hook = await runPluginSetup()
-    // A matching path that already has an explicit baseURL should be left alone.
-    const options: { baseURL?: string } = { baseURL: 'https://explicit.example' }
-    hook!({ request: '/api/_nuxt_icon/ph.json', options })
-    expect(options.baseURL).toBe('https://explicit.example')
+    // Caller intentionally targeting another origin via an http(s)
+    // baseURL — we shouldn't second-guess them.
+    const ctx = simulateRequest(hook!, '/api/_nuxt_icon/ph.json', { baseURL: 'https://explicit.example' })
+    expect(ctx.request).toBe('/api/_nuxt_icon/ph.json')
+    expect(ctx.options.baseURL).toBe('https://explicit.example')
   })
 
   it('matches with startsWith — custom prefixes can be added', async () => {
@@ -209,7 +250,58 @@ describe('cdnFetchPaths client plugin', () => {
       },
     }
     const hook = await runPluginSetup()
-    expect(simulateRequest(hook!, '/api/my-custom-route/foo')).toBe('https://app.example.com')
-    expect(simulateRequest(hook!, '/api/other/foo')).toBeUndefined()
+    expect(simulateRequest(hook!, '/api/my-custom-route/foo').request)
+      .toBe('https://app.example.com/api/my-custom-route/foo')
+    expect(simulateRequest(hook!, '/api/other/foo').request).toBe('/api/other/foo')
+  })
+
+  describe('$fetch.native wrap', () => {
+    it('rebinds $fetch.native so captured references see the rewrite', async () => {
+      state.runtimeConfig = {
+        app: { cdnURL: 'https://app.example.com' },
+        public: {
+          componentPreview: true,
+          nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        },
+      }
+      await runPluginSetup()
+      // Simulate a module (e.g. @nuxt/icon) capturing $fetch.native AFTER
+      // our plugin ran and calling it with a matching relative path.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const captured = ((globalThis as any).$fetch as any).native as NativeFetch
+      await captured('/api/_nuxt_icon/ph.json')
+      expect(state.nativeCalls).toHaveLength(1)
+      expect(state.nativeCalls[0]!.input).toBe('https://app.example.com/api/_nuxt_icon/ph.json')
+    })
+
+    it('leaves non-matching relative requests untouched on native fetch', async () => {
+      state.runtimeConfig = {
+        app: { cdnURL: 'https://app.example.com' },
+        public: {
+          componentPreview: true,
+          nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        },
+      }
+      await runPluginSetup()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const captured = ((globalThis as any).$fetch as any).native as NativeFetch
+      await captured('/api/other/thing.json')
+      expect(state.nativeCalls[0]!.input).toBe('/api/other/thing.json')
+    })
+
+    it('leaves absolute URLs untouched on native fetch', async () => {
+      state.runtimeConfig = {
+        app: { cdnURL: 'https://app.example.com' },
+        public: {
+          componentPreview: true,
+          nuxtComponentPreview: { cdnFetchPaths: ['/api/_nuxt_icon/'] },
+        },
+      }
+      await runPluginSetup()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const captured = ((globalThis as any).$fetch as any).native as NativeFetch
+      await captured('https://somewhere.else/api/_nuxt_icon/ph.json')
+      expect(state.nativeCalls[0]!.input).toBe('https://somewhere.else/api/_nuxt_icon/ph.json')
+    })
   })
 })


### PR DESCRIPTION
## Problem

Two related gaps in the `cdnFetchPaths` plugin's onRequest-only override, discovered when verifying PR-preview against a real Drupal Canvas env (kickstart PR #1064):

1. **Nuxt-default baseURL shadows the rewrite.** Nuxt creates `globalThis.$fetch` via `$fetch.create({ baseURL })`. By the time our onRequest hook fires, `options.baseURL` is already populated (with the Nuxt app baseURL default). The previous "respect caller-provided baseURL" early-return (`if (options.baseURL) return`) couldn't tell "caller set it" apart from "ofetch-default set it" and short-circuited on every call, so matching paths like `/_i18n/...` were never rewritten.
2. **`$fetch.native` bypasses ofetch.** Modules using the raw platform fetch via `globalThis.$fetch.native` (e.g. `@nuxt/icon` via `setFetch($fetch.native)`) skip ofetch and the onRequest hook entirely, so their requests for matching paths still go to the embedder origin.

Live symptom on a Drupal Canvas preview: icons (nuxt-icon) and translation messages (`@nuxtjs/i18n`) both 404'd because they hit the Drupal origin instead of the Nuxt origin, despite the preview app-loader setting `app.cdnURL` and the plugin being active.

## Fix

- **Mutate `ctx.request`, not `options.baseURL`.** Rewriting the request to an absolute URL (`cdnURL + path`) sidesteps ofetch's baseURL merging — the Nuxt-default baseURL no longer matters.
- **Still respect explicit absolute (`http://` / `https://`) caller baseURLs** — that's the unambiguous signal the caller deliberately wanted another origin.
- **Rebind `globalThis.$fetch.native`**: because the plugin is `enforce: 'pre'`, we run before other modules capture `.native`. The rebound function prepends `cdnURL` to matching relative URLs and delegates to the original.

## Testing

Restructured the unit tests around observing the rewritten `ctx.request` instead of `options.baseURL`. Added coverage for:
- `$fetch.native` rebind (icon-style capture pattern)
- non-matching and absolute URLs left alone on native fetch
- explicit `http(s)://` caller baseURL respected
- Nuxt-default `''` / `'/'` baseURL overridden

16/16 tests pass locally.

## Test plan

- [x] `vitest` unit suite green
- [x] Verified on Drupal Canvas preview (kickstart PR [drunomics/lupus-nuxt3-kickstart#1064](https://github.com/drunomics/lupus-nuxt3-kickstart/pull/1064), via patch-package) — both `@nuxt/icon` and `@nuxtjs/i18n` requests now rewrite to `app.cdnURL` as expected.

Claude Code: generated with [Claude Code](https://claude.com/claude-code)