### PR TITLE
feat: support multi-value component props

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ withDefaults(defineProps<{
 - `@format` - JSON Schema format for semantic string validation and UI widgets (e.g., date picker). Supported: `date`, `date-time`, `time`, `duration`, `email`, `idn-email`, `hostname`, `idn-hostname`, `ipv4`, `ipv6`, `uuid`, `uri`, `uri-reference`, `iri`, `iri-reference`
 - `@pattern` - JSON Schema regex pattern for string validation (e.g., `(.|\r?\n)*` for multiline/textarea)
 - `@allowed-schemes` - Allowed URI schemes for Canvas field type determination (e.g., `public` or `http, https`)
+- `@maxItems` / `@minItems` - Cardinality bounds for array props (see [Multi-Value Props](#multi-value-array-props))
+- `@itemsFormat` / `@itemsSchemaRef` - Format / `$ref` applied to the *items* of an array prop
 
 Prop titles are auto-generated from the first line of JSDoc or prop name. Use `@title` to override.
 
@@ -295,6 +297,8 @@ For [Drupal Canvas](https://www.drupal.org/project/canvas) integration, special 
 See [TestHero.vue](./playground/components/global/TestHero.vue) and [TestBanner.vue](./playground/components/global/TestBanner.vue) for usage examples.
 
 **Schema references** via `@schemaRef` allow referencing Canvas JSON schema definitions, useful for `stream-wrapper-uri` and `stream-wrapper-image-uri` types. Use shorthand `prefix/name` notation (e.g., `canvas/stream-wrapper-uri` expands to `json-schema-definitions://canvas.module/stream-wrapper-uri`). See [TestStreamWrapper.vue](./playground/components/global/TestStreamWrapper.vue) for examples.
+
+**Multi-value (array) props** are declared as TS array types. Enum element types (`('a' | 'b')[]`, `(10 | 20)[]`) lift into `items.enum` + `items.meta:enum` automatically; `CanvasImage[]` / `CanvasVideo[]` lift into `items.$ref`. Refinements TypeScript can't express are picked up via JSDoc: `@minItems` / `@maxItems` (cardinality), `@itemsFormat` (e.g. `uri`, `date`), `@itemsSchemaRef` (canvas $ref shorthand). See [TestMultiValueProps.vue](./playground/components/global/TestMultiValueProps.vue).
 
 ## Testing
 

--- a/playground/components/global/TestMultiValueProps.vue
+++ b/playground/components/global/TestMultiValueProps.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+withDefaults(defineProps<{
+  /**
+   * Plain text values
+   * @example ["Hello World", "Sample Text"]
+   */
+  textValues?: string[]
+  /**
+   * Limited plain text (max 3)
+   * @maxItems 3
+   */
+  textLimited?: string[]
+  /**
+   * Required text values
+   * @minItems 1
+   */
+  requiredText: string[]
+  /**
+   * Numbers
+   * @example [42, 100]
+   */
+  numbers?: number[]
+  /**
+   * Links (absolute URLs)
+   * @itemsFormat uri
+   * @example ["https://drupal.org", "https://example.com"]
+   */
+  links?: string[]
+  /**
+   * Limited links (max 3)
+   * @itemsFormat uri
+   * @maxItems 3
+   */
+  linksLimited?: string[]
+  /**
+   * Relative links
+   * @itemsFormat uri-reference
+   * @example ["/about", "/contact"]
+   */
+  relativeLinks?: string[]
+  /**
+   * DateTimes
+   * @itemsFormat date-time
+   */
+  dateTimes?: string[]
+  /**
+   * Dates
+   * @itemsFormat date
+   */
+  dates?: string[]
+  /**
+   * Text list (string enum)
+   * @example ["option_one", "option_two"]
+   */
+  listText?: ('option_one' | 'option_two' | 'option_three' | 'option_four')[]
+  /**
+   * Limited text list
+   * @maxItems 3
+   * @enumLabels {"draft": "Draft", "review": "In Review", "live": "Live"}
+   */
+  listTextLimited?: ('draft' | 'review' | 'live')[]
+  /**
+   * Integer list (numeric enum)
+   * @example [10, 20]
+   * @enumLabels {"10": "Ten", "20": "Twenty", "30": "Thirty", "40": "Forty"}
+   */
+  listInt?: (10 | 20 | 30 | 40)[]
+  /**
+   * Gallery images
+   * @maxItems 5
+   */
+  images?: CanvasImage[]
+  /**
+   * Public file attachments
+   * @itemsSchemaRef canvas/stream-wrapper-uri
+   */
+  attachments?: string[]
+}>(), {})
+</script>
+
+<template>
+  <div class="test-multi-value-props" />
+</template>

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -188,6 +188,7 @@ interface PropDefinition {
   // Array support
   'items'?: Partial<PropDefinition>
   'maxItems'?: number
+  'minItems'?: number
 }
 
 // Canvas type mappings - maps TypeScript type names to Canvas $ref values
@@ -359,6 +360,62 @@ function detectMaxItemsTag(tags?: Array<{ name: string, text?: string }>): numbe
 }
 
 /**
+ * Detect @minItems JSDoc tag for array required cardinality.
+ *
+ * Canvas signals "required" for multi-value props via `minItems: 1`.
+ *
+ * @example
+ * // @minItems 1
+ * tags: string[]
+ */
+function detectMinItemsTag(tags?: Array<{ name: string, text?: string }>): number | null {
+  if (!tags) return null
+
+  const minItemsTag = tags.find(t => t.name === 'minItems')
+  if (!minItemsTag?.text?.trim()) return null
+
+  const num = Number.parseInt(minItemsTag.text.trim(), 10)
+  return Number.isNaN(num) ? null : num
+}
+
+/**
+ * Detect @itemsFormat JSDoc tag for the JSON Schema format of array items.
+ *
+ * Canvas-supported formats (uri, uri-reference, date, date-time, email).
+ *
+ * @example
+ * // @itemsFormat uri
+ * links?: string[]
+ */
+function detectItemsFormatTag(tags?: Array<{ name: string, text?: string }>): string | null {
+  if (!tags) return null
+
+  const itemsFormatTag = tags.find(t => t.name === 'itemsFormat')
+  if (!itemsFormatTag?.text?.trim()) return null
+
+  return itemsFormatTag.text.trim()
+}
+
+/**
+ * Detect @itemsSchemaRef JSDoc tag for the $ref of array items.
+ *
+ * Supports the same shorthand notation as @schemaRef.
+ *
+ * @example
+ * // @itemsSchemaRef canvas/stream-wrapper-uri
+ * attachments?: string[]
+ */
+function detectItemsSchemaRefTag(tags?: Array<{ name: string, text?: string }>): SchemaRefResult | null {
+  if (!tags) return null
+
+  const tag = tags.find(t => t.name === 'itemsSchemaRef')
+  if (!tag?.text?.trim()) return null
+
+  // Reuse @schemaRef parser by mapping name to 'schemaRef'.
+  return detectSchemaRefTag([{ name: 'schemaRef', text: tag.text }])
+}
+
+/**
  * Schema type from vue-component-meta
  */
 interface VueMetaSchema {
@@ -379,16 +436,31 @@ function detectArrayFromTypeString(typeStr: string): string | null {
   // Handle T[] syntax: string[], number[], CanvasImage[]
   const bracketMatch = cleanType.match(/^(.+)\[\]$/)
   if (bracketMatch) {
-    return bracketMatch[1]
+    return stripOuterParens(bracketMatch[1])
   }
 
   // Handle Array<T> syntax
   const genericMatch = cleanType.match(/^Array<(.+)>$/i)
   if (genericMatch) {
-    return genericMatch[1]
+    return stripOuterParens(genericMatch[1])
   }
 
   return null
+}
+
+/**
+ * Strip a single layer of outer parens, e.g. `(10 | 20)` -> `10 | 20`.
+ *
+ * TypeScript writes union element types of `T[]` as `(A | B)[]`; the outer
+ * parens trip up the scalar prop helpers (mapVueTypeToJsonSchema,
+ * extractEnumFromType) that operate on the union string directly.
+ */
+function stripOuterParens(type: string): string {
+  const trimmed = type.trim()
+  if (trimmed.startsWith('(') && trimmed.endsWith(')')) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
 }
 
 /**
@@ -904,13 +976,43 @@ export function generateComponentIndex(
               propDef.items = { type: 'object', $ref: canvasRef }
             }
             else {
-              // Array of primitives (string[], number[], boolean[])
-              propDef.items = { type: mapVueTypeToJsonSchema(elementType) }
+              // Array of primitives (string[], number[], boolean[]) — plus
+              // optional refinements from JSDoc / TS union literals applied
+              // to the *items* schema (canvas 1.4 multi-value props).
+              const itemsSchema: Partial<PropDefinition> = {
+                type: mapVueTypeToJsonSchema(elementType),
+              }
+
+              // Element-type enum: detect a string/integer literal union in
+              // the element type and lift it into items.enum + meta:enum.
+              const itemEnumValues = extractEnumFromType(elementType)
+              if (itemEnumValues.length > 0) {
+                itemsSchema.enum = itemEnumValues
+                const metaEnum = extractEnumLabels(prop, itemEnumValues)
+                if (metaEnum) itemsSchema['meta:enum'] = metaEnum
+              }
+
+              // @itemsFormat — applies to a string-typed element (uri, date,
+              // date-time, etc.).
+              const itemsFormat = detectItemsFormatTag(prop.tags)
+              if (itemsFormat) itemsSchema.format = itemsFormat
+
+              // @itemsSchemaRef — $ref for an element that is not a built-in
+              // Canvas alias (CanvasImage/CanvasVideo).
+              const itemsRef = detectItemsSchemaRefTag(prop.tags)
+              if (itemsRef) {
+                itemsSchema.$ref = itemsRef.$ref
+                Object.assign(itemsSchema, getSchemaRefProperties(itemsRef.shorthand))
+              }
+
+              propDef.items = itemsSchema
             }
 
-            // Check for @maxItems
+            // Check for @maxItems / @minItems
             const maxItems = detectMaxItemsTag(prop.tags)
             if (maxItems) propDef.maxItems = maxItems
+            const minItems = detectMinItemsTag(prop.tags)
+            if (minItems) propDef.minItems = minItems
 
             // Extract examples (should be arrays)
             const examples = extractExamples(prop, 'object')

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path'
+import { readFileSync } from 'node:fs'
 import { describe, it, expect, beforeAll } from 'vitest'
 import type { Component } from '@nuxt/schema'
 import type { ComponentIndexData } from '../src/runtime/server/utils/generateComponentIndex'
@@ -540,6 +541,101 @@ describe('Component Index - Prop Metadata Extraction', () => {
         $ref: 'json-schema-definitions://canvas.module/image',
       })
       expect(imagesProp.maxItems).toBe(20)
+    })
+  })
+
+  // ── TestMultiValueProps group ─────────────────────────────────────
+  // Canvas 1.4 multi-value props: each variant matches the shape canvas
+  // expects for arrays of strings/numbers/integers, with optional format,
+  // enum + meta:enum, $ref-on-items, and minItems/maxItems cardinality.
+  // @see web/modules/contrib/canvas/tests/modules/canvas_test_sdc/components/multivalue-props/multivalue-props.component.yml
+  describe('TestMultiValueProps (Canvas 1.4 multi-value props)', () => {
+    let result: ComponentIndexData
+
+    beforeAll(async () => {
+      result = await generateIndex([createMockComp('TestMultiValueProps', 'TestMultiValueProps.vue')])
+    })
+
+    function prop(name: string) {
+      return result.components[0].props.properties[name]
+    }
+
+    it('plain text array → type:array items:{type:string}', () => {
+      expect(prop('textValues')).toMatchObject({
+        type: 'array',
+        items: { type: 'string' },
+      })
+    })
+
+    it('@maxItems lifts cardinality cap to maxItems', () => {
+      expect(prop('textLimited').maxItems).toBe(3)
+    })
+
+    it('@minItems lifts required-ness to minItems on the array', () => {
+      expect(prop('requiredText').minItems).toBe(1)
+      // Non-optional prop still appears in component-level required[] too —
+      // canvas accepts either signal.
+      expect(result.components[0].props.required).toContain('requiredText')
+    })
+
+    it('@itemsFormat lifts string format to items.format', () => {
+      expect(prop('links').items).toEqual({ type: 'string', format: 'uri' })
+      expect(prop('relativeLinks').items).toEqual({ type: 'string', format: 'uri-reference' })
+      expect(prop('dateTimes').items).toEqual({ type: 'string', format: 'date-time' })
+      expect(prop('dates').items).toEqual({ type: 'string', format: 'date' })
+    })
+
+    it('string-literal union element → items.enum + auto meta:enum', () => {
+      expect(prop('listText').items).toEqual({
+        'type': 'string',
+        'enum': ['option_one', 'option_two', 'option_three', 'option_four'],
+        'meta:enum': {
+          option_one: 'Option One',
+          option_two: 'Option Two',
+          option_three: 'Option Three',
+          option_four: 'Option Four',
+        },
+      })
+    })
+
+    it('@enumLabels overrides auto-generated item labels', () => {
+      expect(prop('listTextLimited').items['meta:enum']).toEqual({
+        draft: 'Draft',
+        review: 'In Review',
+        live: 'Live',
+      })
+    })
+
+    it('numeric-literal union element → items.type:integer + enum', () => {
+      expect(prop('listInt').items).toMatchObject({
+        type: 'integer',
+        enum: [10, 20, 30, 40],
+      })
+    })
+
+    it('CanvasImage[] → items:{type:object, $ref:image}', () => {
+      expect(prop('images').items).toEqual({
+        type: 'object',
+        $ref: 'json-schema-definitions://canvas.module/image',
+      })
+      expect(prop('images').maxItems).toBe(5)
+    })
+
+    it('@itemsSchemaRef lifts known-shape $ref + properties to items', () => {
+      expect(prop('attachments').items).toEqual({
+        'type': 'string',
+        '$ref': 'json-schema-definitions://canvas.module/stream-wrapper-uri',
+        'format': 'uri',
+        'x-allowed-schemes': ['public'],
+      })
+    })
+
+    it('overall output matches the canvas_extjs fixture snapshot', () => {
+      const expected = JSON.parse(readFileSync(
+        path.resolve(__dirname, 'fixtures/multivalue-props.component-index.json'),
+        'utf-8',
+      ))
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/test/fixtures/multivalue-props.component-index.json
+++ b/test/fixtures/multivalue-props.component-index.json
@@ -1,0 +1,205 @@
+{
+  "version": "1.0",
+  "components": [
+    {
+      "id": "TestMultiValueProps",
+      "name": "Test Multi Value Props",
+      "category": "Test",
+      "status": "stable",
+      "props": {
+        "type": "object",
+        "required": [
+          "requiredText"
+        ],
+        "properties": {
+          "textValues": {
+            "type": "array",
+            "title": "Plain text values",
+            "items": {
+              "type": "string"
+            },
+            "examples": [
+              [
+                "Hello World",
+                "Sample Text"
+              ]
+            ]
+          },
+          "textLimited": {
+            "type": "array",
+            "title": "Text Limited",
+            "description": "Limited plain text (max 3)",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 3
+          },
+          "requiredText": {
+            "type": "array",
+            "title": "Required text values",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "numbers": {
+            "type": "array",
+            "title": "Numbers",
+            "items": {
+              "type": "number"
+            },
+            "examples": [
+              [
+                42,
+                100
+              ]
+            ]
+          },
+          "links": {
+            "type": "array",
+            "title": "Links (absolute URLs)",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "examples": [
+              [
+                "https://drupal.org",
+                "https://example.com"
+              ]
+            ]
+          },
+          "linksLimited": {
+            "type": "array",
+            "title": "Limited links (max 3)",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            },
+            "maxItems": 3
+          },
+          "relativeLinks": {
+            "type": "array",
+            "title": "Relative links",
+            "items": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "examples": [
+              [
+                "/about",
+                "/contact"
+              ]
+            ]
+          },
+          "dateTimes": {
+            "type": "array",
+            "title": "DateTimes",
+            "items": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "dates": {
+            "type": "array",
+            "title": "Dates",
+            "items": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          "listText": {
+            "type": "array",
+            "title": "Text list (string enum)",
+            "items": {
+              "type": "string",
+              "enum": [
+                "option_one",
+                "option_two",
+                "option_three",
+                "option_four"
+              ],
+              "meta:enum": {
+                "option_one": "Option One",
+                "option_two": "Option Two",
+                "option_three": "Option Three",
+                "option_four": "Option Four"
+              }
+            },
+            "examples": [
+              [
+                "option_one",
+                "option_two"
+              ]
+            ]
+          },
+          "listTextLimited": {
+            "type": "array",
+            "title": "Limited text list",
+            "items": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "review",
+                "live"
+              ],
+              "meta:enum": {
+                "draft": "Draft",
+                "review": "In Review",
+                "live": "Live"
+              }
+            },
+            "maxItems": 3
+          },
+          "listInt": {
+            "type": "array",
+            "title": "List Int",
+            "description": "Integer list (numeric enum)",
+            "items": {
+              "type": "integer",
+              "enum": [
+                10,
+                20,
+                30,
+                40
+              ],
+              "meta:enum": {
+                "10": "Ten",
+                "20": "Twenty",
+                "30": "Thirty",
+                "40": "Forty"
+              }
+            },
+            "examples": [
+              [
+                10,
+                20
+              ]
+            ]
+          },
+          "images": {
+            "type": "array",
+            "title": "Gallery images",
+            "items": {
+              "type": "object",
+              "$ref": "json-schema-definitions://canvas.module/image"
+            },
+            "maxItems": 5
+          },
+          "attachments": {
+            "type": "array",
+            "title": "Public file attachments",
+            "items": {
+              "type": "string",
+              "$ref": "json-schema-definitions://canvas.module/stream-wrapper-uri",
+              "format": "uri",
+              "x-allowed-schemes": [
+                "public"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds component-index generator support for the multi-value prop shapes introduced by [Canvas 1.4](https://www.drupal.org/project/canvas), so TypeScript-authored Vue components can declare array props the same way canvas's SDC `multivalue-props` test component does.

Tracking issue (canvas_extjs side): https://www.drupal.org/project/canvas_extjs/issues/3590288

### What's new in the generator

- `@minItems N` JSDoc tag — required-array cardinality (canvas signals required via `minItems: 1`)
- `@itemsFormat <fmt>` — lifts `format` into `items` (`uri`, `uri-reference`, `date`, `date-time`, …)
- `@itemsSchemaRef <prefix/name>` — lifts `$ref` into `items`, including the known-shape extras (`format` / `x-allowed-schemes` / `contentMediaType`) that already work for scalar `@schemaRef` props
- String- and numeric-literal union element types (`('a'|'b')[]`, `(10|20)[]`) are auto-lifted to `items.enum` + `items.meta:enum`, mirroring the scalar enum behaviour. `@enumLabels` overrides are honoured.
- Paren-stripping fix in `detectArrayFromTypeString` so the existing scalar helpers (`mapVueTypeToJsonSchema`, `extractEnumFromType`) see clean union strings.

### Test coverage

- New `playground/components/global/TestMultiValueProps.vue` covering 14 multi-value variants — the same matrix as canvas's `tests/modules/canvas_test_sdc/components/multivalue-props/multivalue-props.component.yml`.
- 10 new vitest cases in `test/component-index-props.test.ts` covering each refinement.
- Checked-in `test/fixtures/multivalue-props.component-index.json` snapshot used both here (full-output match) and on the canvas_extjs side as a cross-stack contract fixture.

### Cross-stack contract

The same JSON snapshot will be added as a fixture in canvas_extjs (issue #3590288) and exercised in a kernel test, so a change here that breaks the canvas-expected shape gets caught on both sides.

## Test plan

- [x] `npm test` — 119 tests pass (10 new)
- [x] `npm run lint` — no new errors
- [ ] CI green on the PR