### PR TITLE
fix: required props must provide an @example value

### DIFF
--- a/playground/components/global/TestMultiValueProps.vue
+++ b/playground/components/global/TestMultiValueProps.vue
@@ -13,6 +13,7 @@ withDefaults(defineProps<{
   /**
    * Required text values
    * @minItems 1
+   * @example ["Required 1", "Required 2"]
    */
   requiredText: string[]
   /**

--- a/playground/components/global/TestRequiredNoExample.vue
+++ b/playground/components/global/TestRequiredNoExample.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+defineProps<{
+  /**
+   * Required prop with NO @example
+   */
+  requiredNoExample: string
+}>()
+</script>
+
+<template>
+  <div />
+</template>

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -1122,6 +1122,16 @@ export function generateComponentIndex(
       // Apply overrides if present (overrides take priority over JSDoc)
       const override = options.overrides?.[component.pascalName]
 
+      // Required props must carry an @example — canvas core (and consuming
+      // tools like canvas_extjs) assume the SDC `examples` array exists for
+      // required props and silently produce broken field defaults otherwise.
+      // @see Drupal\canvas\Plugin\Canvas\ComponentSource\GeneratedFieldExplicitInputUxComponentSourceBase
+      for (const requiredProp of requiredProps) {
+        if (!props[requiredProp]?.examples?.length) {
+          console.warn(`[nuxt-component-preview] Required prop "${component.pascalName}.${requiredProp}" has no @example. Canvas assumes required props always have one and silently falls back to a null value otherwise — add an @example to the prop.`)
+        }
+      }
+
       const description = override?.description || componentMeta.description
       return {
         id: component.pascalName,

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path'
 import { readFileSync } from 'node:fs'
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import type { Component } from '@nuxt/schema'
 import type { ComponentIndexData } from '../src/runtime/server/utils/generateComponentIndex'
 
@@ -636,6 +636,35 @@ describe('Component Index - Prop Metadata Extraction', () => {
         'utf-8',
       ))
       expect(result).toEqual(expected)
+    })
+  })
+
+  // ── Required-prop @example enforcement ────────────────────────────
+  // Canvas core (GeneratedFieldExplicitInputUxComponentSourceBase) assumes
+  // every required prop carries an example value and silently produces a
+  // null-valued field default otherwise. Catch it at generator time so
+  // downstream tools (canvas_extjs, canvas) don't have to.
+  describe('required-prop @example enforcement', () => {
+    it('warns when a required prop has no @example', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      await generateIndex([createMockComp('TestRequiredNoExample', 'TestRequiredNoExample.vue')])
+      const warning = warn.mock.calls
+        .map(args => args[0])
+        .find(msg => typeof msg === 'string' && msg.includes('requiredNoExample'))
+      expect(warning).toBeDefined()
+      expect(warning).toMatch(/has no @example/)
+      warn.mockRestore()
+    })
+
+    it('does not warn when a required prop carries an @example', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      // TestMultiValueProps.requiredText is required and has @example.
+      await generateIndex([createMockComp('TestMultiValueProps', 'TestMultiValueProps.vue')])
+      const offending = warn.mock.calls
+        .map(args => args[0])
+        .filter(msg => typeof msg === 'string' && msg.includes('has no @example'))
+      expect(offending).toHaveLength(0)
+      warn.mockRestore()
     })
   })
 })

--- a/test/fixtures/multivalue-props.component-index.json
+++ b/test/fixtures/multivalue-props.component-index.json
@@ -40,7 +40,13 @@
             "items": {
               "type": "string"
             },
-            "minItems": 1
+            "minItems": 1,
+            "examples": [
+              [
+                "Required 1",
+                "Required 2"
+              ]
+            ]
           },
           "numbers": {
             "type": "array",


### PR DESCRIPTION
## Summary

Follow-up to #174. Canvas core assumes the SDC `examples` array exists for required props — see [`GeneratedFieldExplicitInputUxComponentSourceBase.php:1179`](https://git.drupalcode.org/project/canvas/-/blob/1.x/src/Plugin/Canvas/ComponentSource/GeneratedFieldExplicitInputUxComponentSourceBase.php#L1179), the required branch unconditionally indexes `$schema['properties'][$name]['examples'][0]`.

`TestMultiValueProps.requiredText` was the only required-array variant in the fixture and shipped without an `@example`, so when the canvas_extjs cross-stack kernel test consumed the snapshot it triggered two PHP warnings on drupalcode CI — see [job 9828388](https://git.drupalcode.org/project/canvas_extjs/-/jobs/9828388).

## Changes

- Add `@example` to `requiredText` in `TestMultiValueProps.vue`
- Regenerate the checked-in component-index snapshot in `test/fixtures/multivalue-props.component-index.json`

## Test plan

- [x] `npm test` — 119 tests pass
- [x] canvas_extjs kernel test now runs warning-free
- [ ] canvas_extjs CI green once the matching fixture commit lands on its side