### PR TITLE
resolve dev-mode Nuxt entry via Vite @fs absolute path

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -125,18 +125,30 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Resolve entry path for dev.
-    // Vite serves files relative to the project root, so we need to
-    // convert the absolute appDir to a path relative to rootDir.
-    // Append buildId as cache buster so browser refetches after restart.
+    //
+    // The Nuxt app entry lives in node_modules (nuxt/dist/app), which the
+    // Vite dev server does NOT serve from a root-relative URL. Vite addresses
+    // such files via its `@fs/<absolute-path>` mechanism, so we must build the
+    // entry URL from the entry's absolute filesystem path, not a synthesized
+    // root-relative path. (A prior implementation stripped appDir down to a
+    // `node_modules/...` path relative to rootDir; that 404s whenever appDir
+    // sits under rootDir — i.e. every normal single-project frontend.)
+    //
+    // The entry filename also differs from production: in dev Vite always uses
+    // the async entry (`@nuxt/vite-builder` forces `useAsyncEntry` whenever
+    // `nuxt.options.dev` is set), so the file is `entry.async.js`, not
+    // `entry.js`.
+    //
+    // Append buildId as cache buster so the browser refetches after a restart.
     if (nuxt.options.dev) {
       nuxt.hook('ready', () => {
         const appDir = nuxt.options.appDir.replace(/\/+$/, '')
-        const rootDir = nuxt.options.rootDir.replace(/\/+$/, '')
-        const relativeAppDir = appDir.startsWith(rootDir)
-          ? appDir.slice(rootDir.length + 1)
-          : appDir
+        const baseURL = (nuxt.options.app.baseURL || '/').replace(/\/+$/, '')
+        const assetsDir = (nuxt.options.app.buildAssetsDir || '/_nuxt/').replace(/^\/+|\/+$/g, '')
+        const useAsyncEntry = nuxt.options.experimental?.asyncEntry || nuxt.options.dev
+        const entryName = useAsyncEntry ? 'entry.async' : 'entry'
         const buildId = nuxt.options.appConfig?.nuxt?.buildId
-        resolvedEntryPath = `/_nuxt/${relativeAppDir}/entry.js` + (buildId ? `?v=${buildId}` : '')
+        resolvedEntryPath = `${baseURL}/${assetsDir}/@fs${appDir}/${entryName}.js` + (buildId ? `?v=${buildId}` : '')
       })
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -142,13 +142,16 @@ export default defineNuxtModule<ModuleOptions>({
     // Append buildId as cache buster so the browser refetches after a restart.
     if (nuxt.options.dev) {
       nuxt.hook('ready', () => {
-        const appDir = nuxt.options.appDir.replace(/\/+$/, '')
+        // Vite's @fs URLs use posix-style paths with a leading slash, even on
+        // Windows (`/@fs/C:/...`), and the dev server decodes the URL before
+        // matching it against the filesystem.
+        const appDir = nuxt.options.appDir.replace(/\\/g, '/').replace(/\/+$/, '')
+        const fsPath = encodeURI(appDir.startsWith('/') ? appDir : `/${appDir}`)
         const baseURL = (nuxt.options.app.baseURL || '/').replace(/\/+$/, '')
         const assetsDir = (nuxt.options.app.buildAssetsDir || '/_nuxt/').replace(/^\/+|\/+$/g, '')
-        const useAsyncEntry = nuxt.options.experimental?.asyncEntry || nuxt.options.dev
-        const entryName = useAsyncEntry ? 'entry.async' : 'entry'
+        const prefix = assetsDir ? `${baseURL}/${assetsDir}` : baseURL
         const buildId = nuxt.options.appConfig?.nuxt?.buildId
-        resolvedEntryPath = `${baseURL}/${assetsDir}/@fs${appDir}/${entryName}.js` + (buildId ? `?v=${buildId}` : '')
+        resolvedEntryPath = `${prefix}/@fs${fsPath}/entry.async.js` + (buildId ? `?v=${buildId}` : '')
       })
     }
 


### PR DESCRIPTION
  ## Problem

  In **dev mode** (`nuxt dev`), the app-loader fails to load the Nuxt app entry in cross-origin previews (Nuxt frontend embedded in Drupal Canvas):

  ```
  GET /nuxt-component-preview/app-loader.js   → 200
  GET /_nuxt/node_modules/nuxt/dist/app/entry.js   → 404 (see screenshot)
  ```

<img width="1099" height="159" alt="Untitled" src="https://github.com/user-attachments/assets/a276e178-ddb8-4660-845c-ecf7ef2c5bf5" />


  The Vite dev server actually serves the entry from:

  ```
  /_nuxt/@fs/<project>/node_modules/nuxt/dist/app/entry.async.js
  ```

  `nuxt build` / `nuxt generate` are unaffected (they read the real chunk from `build:manifest`).

  ## Root cause

  The `if (nuxt.options.dev)` branch in `src/module.ts` **synthesizes** a build-style entry URL instead of using the form Vite actually serves. Two things are wrong:

  1. **Path.** It strips `appDir` to a path relative to `rootDir`:
     ```ts
     const relativeAppDir = appDir.startsWith(rootDir) ? appDir.slice(rootDir.length + 1) : appDir
     resolvedEntryPath = `/_nuxt/${relativeAppDir}/entry.js` + ...
     ```
     The entry lives in `node_modules/nuxt/dist/app`, which Vite does **not** serve from a root-relative URL — it serves it via the `@fs/<absolute-path>` mechanism. For any normal single-project frontend (where `appDir` is
  under `rootDir`), this produces `/_nuxt/node_modules/nuxt/dist/app/entry.js`, which 404s.

     This is also why the playground masks the bug: there `appDir` (`<repo>/node_modules/...`) is **not** under `rootDir` (`<repo>/playground`), so the `startsWith` branch is skipped and the leftover absolute path happens
  to be served by Vite. Real consumer projects don't have that layout.

  2. **Filename.** Dev uses the **async** entry. `@nuxt/vite-builder` resolves `useAsyncEntry = experimental.asyncEntry || nuxt.options.dev`, so in dev the entry is always `entry.async.js`, not `entry.js`.

  ## Fix

  Build the dev entry URL from the entry's absolute filesystem path using Vite's canonical `@fs/` prefix, and use the async entry filename.

  Result: `/_nuxt/@fs/<project>/node_modules/nuxt/dist/app/entry.async.js`, which matches what the dev server serves.

  ## Scope / safety

  - Change is confined to the `if (nuxt.options.dev)` branch. The `!nuxt.options.dev` path (`build:manifest`, used by both `nuxt build` and `nuxt generate`) is untouched.
  - `baseURL` / `buildAssetsDir` are now honored for non-default configs.

  ## Verification

  - Playground `nuxt dev`: the app-loader now emits the `@fs` URL and it returns **200** (previously the synthesized path; the playground's monorepo layout hid the breakage).
  - Confirmed in a real cross-origin setup (separate-origin Drupal Canvas backend + `nuxt dev` frontend): preview now renders; entry request returns 200 instead of 404.
  - `nuxt build` + `node .output/server/index.mjs`: unchanged, still renders previews.
  
  ## Acknowledgement

This PR was written with the help of AI, tho I manually verified and tested it within my nuxt (v4.4.6) project.