### PR TITLE
fix: keep node_modules components so includePackages works for layers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -220,16 +220,12 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt.hook('app:templatesGenerated', async () => {
         const globalComponents = nuxt.apps.default.components.filter(c => c.global)
 
-        // Pass component objects directly with proper names resolved by Nuxt
-        const components = globalComponents
-          .filter(c => !c.filePath.includes('node_modules'))
-          .map(c => ({
-            pascalName: c.pascalName,
-            kebabName: c.kebabName,
-            filePath: c.filePath,
-            shortPath: c.shortPath,
-            global: c.global,
-          }))
+        // node_modules (layer/package) components are intentionally kept:
+        // generateComponentIndex applies the includePackages / include.directories
+        // filters, so dropping them here would make those options dead for layer
+        // components and silently shrink the registry to project-local files.
+        const { collectIndexComponents } = await import('./runtime/server/utils/generateComponentIndex')
+        const components = collectIndexComponents(globalComponents)
 
         // Write config to file for the server handler to generate from.
         fs.writeFileSync(configPath, JSON.stringify({

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -12,6 +12,26 @@ export function extractPackageName(filePath: string): string | null {
   return match ? match[1].replace(/\\/g, '/') : null // Normalize to forward slashes
 }
 
+/** Lightweight component shape written to the index config file. */
+export type IndexComponent = Pick<Component, 'pascalName' | 'kebabName' | 'filePath' | 'shortPath' | 'global'>
+
+/**
+ * Map Nuxt's resolved global components to the shape written to the index
+ * config. node_modules (layer/package) components are intentionally retained:
+ * generateComponentIndex applies the includePackages / include.directories
+ * filters downstream, so dropping them here would make those options dead for
+ * layer components and silently shrink the registry to project-local files.
+ */
+export function collectIndexComponents(globalComponents: Component[]): IndexComponent[] {
+  return globalComponents.map(c => ({
+    pascalName: c.pascalName,
+    kebabName: c.kebabName,
+    filePath: c.filePath,
+    shortPath: c.shortPath,
+    global: c.global,
+  }))
+}
+
 export interface CategoryDirectoryOptions {
   directory: true
   fallback?: string

--- a/test/includePackages.test.ts
+++ b/test/includePackages.test.ts
@@ -1,5 +1,7 @@
-import { resolve } from 'node:path'
-import { describe, it, expect } from 'vitest'
+import { dirname, join, resolve } from 'node:path'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { afterAll, beforeAll, describe, it, expect } from 'vitest'
 import type { Component } from '@nuxt/schema'
 import { collectIndexComponents, extractPackageName, generateComponentIndex } from '../src/runtime/server/utils/generateComponentIndex'
 
@@ -140,6 +142,80 @@ describe('includePackages feature', () => {
       const unixPath = '/node_modules/test-pkg/Component.vue'
       expect(extractPackageName(windowsPath)).toBe('test-pkg')
       expect(extractPackageName(unixPath)).toBe('test-pkg')
+    })
+  })
+
+  // The tests above feed non-existent /fake/node_modules/... paths, so those
+  // components are dropped by the existsSync guard *before* the package filter
+  // runs — they do not actually exercise the includePackages branch. These
+  // tests write a real .vue under a node_modules path so existsSync passes and
+  // the default "ignore all packages" logic is genuinely proven.
+  describe('default exclusion with a real on-disk node_modules component', () => {
+    const tsconfigPath = resolve(process.cwd(), 'playground/tsconfig.json')
+    const localPath = resolve(process.cwd(), 'playground/components/global/TestButton.vue')
+
+    let tmpRoot: string
+    let pkgComponentPath: string
+
+    beforeAll(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'ncp-pkg-'))
+      // A genuine node_modules path that exists on disk.
+      pkgComponentPath = join(tmpRoot, 'node_modules', '@acme', 'ui-kit', 'AcmeButton.vue')
+      mkdirSync(dirname(pkgComponentPath), { recursive: true })
+      writeFileSync(pkgComponentPath, [
+        '<template><button>{{ label }}</button></template>',
+        '<script setup lang="ts">',
+        'defineProps<{',
+        '  /**',
+        '   * Button label',
+        '   * @example Go',
+        '   */',
+        '  label?: string',
+        '}>()',
+        '</script>',
+        '',
+      ].join('\n'))
+    })
+
+    afterAll(() => {
+      rmSync(tmpRoot, { recursive: true, force: true })
+    })
+
+    const make = (name: string, filePath: string): Partial<Component> => ({
+      pascalName: name,
+      kebabName: name.toLowerCase(),
+      filePath,
+      shortPath: filePath,
+      global: true,
+    })
+
+    const idsFor = (includePackages: boolean | string[] | undefined) =>
+      generateComponentIndex(
+        [make('UserButton', localPath), make('AcmeButton', pkgComponentPath)] as Component[],
+        tsconfigPath,
+        { category: 'Test', status: 'stable', includePackages },
+      ).components.map(c => c.id)
+
+    it('excludes the existing node_modules component when includePackages is undefined', () => {
+      expect(idsFor(undefined)).toEqual(['UserButton'])
+    })
+
+    it('excludes the existing node_modules component when includePackages is false', () => {
+      expect(idsFor(false)).toEqual(['UserButton'])
+    })
+
+    it('includes it when includePackages is true', () => {
+      const ids = idsFor(true)
+      expect(ids).toContain('UserButton')
+      expect(ids).toContain('AcmeButton')
+    })
+
+    it('includes it only when its package is whitelisted', () => {
+      expect(idsFor(['@acme/ui-kit'])).toContain('AcmeButton')
+    })
+
+    it('excludes it when a different package is whitelisted', () => {
+      expect(idsFor(['@other/pkg'])).not.toContain('AcmeButton')
     })
   })
 })

--- a/test/includePackages.test.ts
+++ b/test/includePackages.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import type { Component } from '@nuxt/schema'
-import { extractPackageName, generateComponentIndex } from '../src/runtime/server/utils/generateComponentIndex'
+import { collectIndexComponents, extractPackageName, generateComponentIndex } from '../src/runtime/server/utils/generateComponentIndex'
 
 describe('includePackages feature', () => {
   describe('extractPackageName', () => {
@@ -21,6 +21,43 @@ describe('includePackages feature', () => {
       expect(extractPackageName('/components/MyComponent.vue')).toBe(null)
       expect(extractPackageName('/src/utils/helper.js')).toBe(null)
       expect(extractPackageName('C:\\projects\\app\\index.js')).toBe(null)
+    })
+  })
+
+  describe('collectIndexComponents (app:templatesGenerated collection)', () => {
+    const make = (name: string, filePath: string): Partial<Component> => ({
+      pascalName: name,
+      kebabName: name.toLowerCase(),
+      filePath,
+      shortPath: filePath,
+      global: true,
+    })
+
+    // Regression guard: the module hook must NOT drop node_modules components.
+    // They are filtered downstream by generateComponentIndex according to
+    // includePackages; pre-filtering them here made that option dead for layer
+    // components, silently shrinking the registry to project-local files.
+    it('keeps node_modules (layer/package) components', () => {
+      const components = [
+        make('LocalCard', '/app/components/Canvas/Card.vue'),
+        make('LayoutGrid', '/app/node_modules/@drunomics/lupus-nuxt-kickstart-components/components/Canvas/Layout/layout-grid.vue'),
+        make('NuxtIcon', '/app/node_modules/@nuxt/icon/Icon.vue'),
+      ] as Component[]
+
+      const collected = collectIndexComponents(components)
+
+      expect(collected).toHaveLength(3)
+      expect(collected.map(c => c.pascalName)).toEqual(['LocalCard', 'LayoutGrid', 'NuxtIcon'])
+      // The node_modules paths survive so includePackages can act on them.
+      expect(collected.some(c => c.filePath.includes('node_modules'))).toBe(true)
+    })
+
+    it('projects only the fields written to the index config', () => {
+      const collected = collectIndexComponents([
+        { pascalName: 'Foo', kebabName: 'foo', filePath: '/a/Foo.vue', shortPath: 'Foo.vue', global: true, mode: 'all' },
+      ] as unknown as Component[])
+
+      expect(Object.keys(collected[0]).sort()).toEqual(['filePath', 'global', 'kebabName', 'pascalName', 'shortPath'])
     })
   })
 


### PR DESCRIPTION
## Problem

`componentIndex.includePackages` / `include.directories` are documented as the way to index components that a site pulls in as a Nuxt **layer** (e.g. a shared component library under `node_modules/@org/...`). They were **dead** for layer components.

The `app:templatesGenerated` hook collected the global components and hard-stripped every `node_modules` entry *before* writing the index config:

```js
const components = globalComponents
  .filter(c => !c.filePath.includes('node_modules'))
  .map(...)
```

`generateComponentIndex` already applies `includePackages` / `include.directories` / `exclude.components` to decide which `node_modules` components to index — but it never saw them, because the hook removed them first. Result: a site extending a component library as a layer registered only its own project-local components, **with no error** — the registry just looked shorter than the source tree.

This surfaced on a Lupus Decoupled frontend extending `@drunomics/lupus-nuxt-kickstart-components`: the core layer ships `includePackages: true` + `include.directories: ['Canvas']`, yet only the 7 project-local Canvas components registered instead of the full ~20-component library.

## Fix

Extract the collection step into `collectIndexComponents()` (in `generateComponentIndex.ts`, next to the other pure index helpers), which keeps **every** global component. `generateComponentIndex` remains the single place that filters `node_modules` components, honouring `includePackages`:

- `false` / `undefined` → exclude all packages (unchanged default)
- `true` → include all packages
- `string[]` → include only the listed packages

So default behaviour is identical; layer components now actually flow through when a project opts in.

## Tests

`test/includePackages.test.ts`:
- `collectIndexComponents` keeps `node_modules` (layer/package) components so `includePackages` can act on them — the regression guard for this bug.
- It projects only the fields written to the index config.

Full suite green locally (`npm test`, 123 passed) — the playground integration tests exercise the patched hook end-to-end. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)