### PR TITLE
refactor: MCD-1297: Derive the schema type of @schemaRef props from the TypeScript type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,6 @@ withDefaults(defineProps<{
 - `@contentMediaType text/html` - For string props: enables rich text editing in Canvas
 - `@formattingContext block|inline` - Controls formatting (default: `block`)
 - `@schemaRef` - Reference a JSON schema definition (see below)
-- `@schemaType` - JSON Schema type of a `@schemaRef` prop (default `string`; use `object` for object definitions)
 - `@format` - JSON Schema format for semantic string validation and UI widgets (e.g., date picker). Supported: `date`, `date-time`, `time`, `duration`, `email`, `idn-email`, `hostname`, `idn-hostname`, `ipv4`, `ipv6`, `uuid`, `uri`, `uri-reference`, `iri`, `iri-reference`
 - `@pattern` - JSON Schema regex pattern for string validation (e.g., `(.|\r?\n)*` for multiline/textarea)
 - `@allowed-schemes` - Allowed URI schemes for Canvas field type determination (e.g., `public` or `http, https`)
@@ -299,13 +298,12 @@ See [TestHero.vue](./playground/components/global/TestHero.vue) and [TestBanner.
 
 **Schema references** via `@schemaRef` allow referencing JSON schema definitions, useful for `stream-wrapper-uri` and `stream-wrapper-image-uri` types. Use shorthand `prefix/name` notation (e.g., `canvas/stream-wrapper-uri` expands to `json-schema-definitions://canvas.module/stream-wrapper-uri`). See [TestStreamWrapper.vue](./playground/components/global/TestStreamWrapper.vue) for examples.
 
-The shorthand resolves against any Drupal extension that ships a `schema.json`, not only Canvas — so a site's own module can define richer definitions than the built-in ones. Canvas decides a prop's storage from its `type` *before* resolving the `$ref`, and a prop typed as a TypeScript interface carries no JSON Schema type, so an object definition needs `@schemaType object` alongside the ref:
+The shorthand resolves against any Drupal extension that ships a `schema.json`, not only Canvas — so a site's own module can define richer definitions than the built-in ones. Canvas decides a prop's storage from its `type` *before* resolving the `$ref`, so an object definition only matches a prop carrying `type: object`. That type is derived from the prop's TypeScript type — an object-typed prop yields `object`, everything else maps as usual:
 
 ```vue
 /**
  * Image
  * @schemaRef lupus_image/image
- * @schemaType object
  */
 media?: LupusImage
 ```

--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ withDefaults(defineProps<{
 - `@enumLabels` - Custom labels for `meta:enum` (full or partial)
 - `@contentMediaType text/html` - For string props: enables rich text editing in Canvas
 - `@formattingContext block|inline` - Controls formatting (default: `block`)
-- `@schemaRef` - Reference Canvas JSON schema definitions (see below)
+- `@schemaRef` - Reference a JSON schema definition (see below)
+- `@schemaType` - JSON Schema type of a `@schemaRef` prop (default `string`; use `object` for object definitions)
 - `@format` - JSON Schema format for semantic string validation and UI widgets (e.g., date picker). Supported: `date`, `date-time`, `time`, `duration`, `email`, `idn-email`, `hostname`, `idn-hostname`, `ipv4`, `ipv6`, `uuid`, `uri`, `uri-reference`, `iri`, `iri-reference`
 - `@pattern` - JSON Schema regex pattern for string validation (e.g., `(.|\r?\n)*` for multiline/textarea)
 - `@allowed-schemes` - Allowed URI schemes for Canvas field type determination (e.g., `public` or `http, https`)
@@ -296,7 +297,18 @@ For [Drupal Canvas](https://www.drupal.org/project/canvas) integration, special 
 
 See [TestHero.vue](./playground/components/global/TestHero.vue) and [TestBanner.vue](./playground/components/global/TestBanner.vue) for usage examples.
 
-**Schema references** via `@schemaRef` allow referencing Canvas JSON schema definitions, useful for `stream-wrapper-uri` and `stream-wrapper-image-uri` types. Use shorthand `prefix/name` notation (e.g., `canvas/stream-wrapper-uri` expands to `json-schema-definitions://canvas.module/stream-wrapper-uri`). See [TestStreamWrapper.vue](./playground/components/global/TestStreamWrapper.vue) for examples.
+**Schema references** via `@schemaRef` allow referencing JSON schema definitions, useful for `stream-wrapper-uri` and `stream-wrapper-image-uri` types. Use shorthand `prefix/name` notation (e.g., `canvas/stream-wrapper-uri` expands to `json-schema-definitions://canvas.module/stream-wrapper-uri`). See [TestStreamWrapper.vue](./playground/components/global/TestStreamWrapper.vue) for examples.
+
+The shorthand resolves against any Drupal extension that ships a `schema.json`, not only Canvas — so a site's own module can define richer definitions than the built-in ones. Canvas decides a prop's storage from its `type` *before* resolving the `$ref`, and a prop typed as a TypeScript interface carries no JSON Schema type, so an object definition needs `@schemaType object` alongside the ref:
+
+```vue
+/**
+ * Image
+ * @schemaRef lupus_image/image
+ * @schemaType object
+ */
+media?: LupusImage
+```
 
 **Multi-value (array) props** are declared as TS array types. Enum element types (`('a' | 'b')[]`, `(10 | 20)[]`) lift into `items.enum` + `items.meta:enum` automatically; `CanvasImage[]` / `CanvasVideo[]` lift into `items.$ref`. Refinements TypeScript can't express are picked up via JSDoc: `@minItems` / `@maxItems` (cardinality), `@itemsFormat` (e.g. `uri`, `date`), `@itemsSchemaRef` (canvas $ref shorthand). See [TestMultiValueProps.vue](./playground/components/global/TestMultiValueProps.vue).
 

--- a/playground/components/global/TestSchemaRefFile.vue
+++ b/playground/components/global/TestSchemaRefFile.vue
@@ -34,6 +34,15 @@ defineProps<{
   webImageUrl?: string
 
   /**
+   * Rich image
+   *
+   * An object $ref defined by a Drupal extension's own schema.json.
+   * @schemaRef lupus_image/image
+   * @schemaType object
+   */
+  richImage?: { src: string }
+
+  /**
    * Regular text
    *
    * A regular string prop without schema ref for comparison.

--- a/playground/components/global/TestSchemaRefFile.vue
+++ b/playground/components/global/TestSchemaRefFile.vue
@@ -5,6 +5,14 @@
  * NOTE: This is a test-only component - stream-wrapper-uri is not yet
  * fully supported in Canvas (it falls back to Link field).
  */
+
+/** A rich image object, as a site module's own schema.json defines it. */
+interface TestRichImage {
+  src: string
+  alt?: string
+  copyright?: string
+}
+
 defineProps<{
   /**
    * File URI
@@ -38,9 +46,8 @@ defineProps<{
    *
    * An object $ref defined by a Drupal extension's own schema.json.
    * @schemaRef lupus_image/image
-   * @schemaType object
    */
-  richImage?: { src: string }
+  richImage?: TestRichImage
 
   /**
    * Regular text

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -362,6 +362,38 @@ function detectAllowedSchemesTag(tags?: Array<{ name: string, text?: string }>):
   return schemesTag.text.trim().split(/[,\s]+/).filter(Boolean)
 }
 
+/** JSON Schema types a `@schemaType` tag may name. */
+const SCHEMA_TYPES = ['string', 'number', 'integer', 'boolean', 'object', 'array'] as const
+
+/**
+ * Detect the @schemaType JSDoc tag naming the JSON Schema type of a $ref prop.
+ *
+ * Canvas resolves a prop's storage from `type` before it resolves the `$ref`,
+ * so a `$ref` pointing at an object definition only matches if the prop also
+ * declares `type: object`. The prop's TypeScript type is an interface name,
+ * which carries no JSON Schema type, hence this tag. Defaults to `string`,
+ * which is what every Canvas URI `$ref` needs.
+ *
+ * @example
+ * // @schemaRef lupus_image/image
+ * // @schemaType object
+ * media?: LupusImage
+ */
+function detectSchemaTypeTag(tags?: Array<{ name: string, text?: string }>): string | null {
+  if (!tags) return null
+
+  const schemaTypeTag = tags.find(t => t.name === 'schemaType')
+  const value = schemaTypeTag?.text?.trim()
+  if (!value) return null
+
+  if (!(SCHEMA_TYPES as readonly string[]).includes(value)) {
+    console.warn(`[nuxt-component-preview] Invalid @schemaType value: ${value}`)
+    return null
+  }
+
+  return value
+}
+
 /**
  * Detect @maxItems JSDoc tag for array cardinality.
  *
@@ -1076,7 +1108,7 @@ export function generateComponentIndex(
             // (e.g., format, x-allowed-schemes, contentMediaType)
             const additionalProps = getSchemaRefProperties(schemaRefResult.shorthand)
             acc[prop.name] = buildPropDefinition(prop, {
-              type: 'string',
+              type: detectSchemaTypeTag(prop.tags) ?? 'string',
               $ref: schemaRefResult.$ref,
               ...additionalProps,
             })

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -362,36 +362,32 @@ function detectAllowedSchemesTag(tags?: Array<{ name: string, text?: string }>):
   return schemesTag.text.trim().split(/[,\s]+/).filter(Boolean)
 }
 
-/** JSON Schema types a `@schemaType` tag may name. */
-const SCHEMA_TYPES = ['string', 'number', 'integer', 'boolean', 'object', 'array'] as const
-
 /**
- * Detect the @schemaType JSDoc tag naming the JSON Schema type of a $ref prop.
+ * Derive the JSON Schema type of a `@schemaRef` prop from its TypeScript type.
  *
  * Canvas resolves a prop's storage from `type` before it resolves the `$ref`,
  * so a `$ref` pointing at an object definition only matches if the prop also
- * declares `type: object`. The prop's TypeScript type is an interface name,
- * which carries no JSON Schema type, hence this tag. Defaults to `string`,
- * which is what every Canvas URI `$ref` needs.
+ * carries `type: object`. The prop's TypeScript declaration already states
+ * that, and TypeScript is a hard prerequisite of the whole extraction, so the
+ * type is read off the resolved vue-component-meta schema rather than
+ * restated in JSDoc.
  *
  * @example
  * // @schemaRef lupus_image/image
- * // @schemaType object
- * media?: LupusImage
+ * media?: LupusImage  // -> type: object
  */
-function detectSchemaTypeTag(tags?: Array<{ name: string, text?: string }>): string | null {
-  if (!tags) return null
+function deriveSchemaRefType(schema: string | VueMetaSchema | undefined, typeString: string): string {
+  if (schema && typeof schema !== 'string') {
+    if (schema.kind === 'object') return 'object'
 
-  const schemaTypeTag = tags.find(t => t.name === 'schemaType')
-  const value = schemaTypeTag?.text?.trim()
-  if (!value) return null
-
-  if (!(SCHEMA_TYPES as readonly string[]).includes(value)) {
-    console.warn(`[nuxt-component-preview] Invalid @schemaType value: ${value}`)
-    return null
+    // Optional props resolve to `{ kind: 'enum', schema: ['undefined', …] }`.
+    if (schema.kind === 'enum' && Array.isArray(schema.schema)
+      && schema.schema.some(member => typeof member !== 'string' && member?.kind === 'object')) {
+      return 'object'
+    }
   }
 
-  return value
+  return mapVueTypeToJsonSchema(typeString)
 }
 
 /**
@@ -998,7 +994,13 @@ export function generateComponentIndex(
     return true
   })
 
-  const checker = createChecker(tsconfigPath, { printer: { newLine: 1 } })
+  // `schema: true` resolves each prop's TypeScript type into a structured
+  // schema ({ kind: 'object' | 'array' | 'enum', … }) instead of a bare type
+  // string. The nested `schema` members are lazy getters, so the cost is one
+  // level per prop. Prop shapes TypeScript states but a type string cannot —
+  // an object-typed `@schemaRef` prop, an optional array — are only visible
+  // this way.
+  const checker = createChecker(tsconfigPath, { schema: true, printer: { newLine: 1 } })
 
   const componentData = filtered.map((component) => {
     try {
@@ -1108,7 +1110,7 @@ export function generateComponentIndex(
             // (e.g., format, x-allowed-schemes, contentMediaType)
             const additionalProps = getSchemaRefProperties(schemaRefResult.shorthand)
             acc[prop.name] = buildPropDefinition(prop, {
-              type: detectSchemaTypeTag(prop.tags) ?? 'string',
+              type: deriveSchemaRefType(prop.schema as string | VueMetaSchema | undefined, prop.type),
               $ref: schemaRefResult.$ref,
               ...additionalProps,
             })

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -383,17 +383,17 @@ describe('Component Index - Prop Metadata Extraction', () => {
       expect(fileUriProp['x-allowed-schemes']).toEqual(['public'])
     })
 
-    it('honours @schemaType for an object $ref', () => {
+    it('derives type object for an object-typed @schemaRef prop', () => {
       const richImageProp = result.components[0].props.properties.richImage
 
       // Canvas resolves storage from `type` before resolving `$ref`, so an
-      // object definition only matches when the prop declares type: object.
+      // object definition only matches when the prop carries type: object.
       expect(richImageProp.type).toBe('object')
       expect(richImageProp['$ref']).toBe('json-schema-definitions://lupus_image.module/image')
       expect(richImageProp.title).toBe('Rich image')
     })
 
-    it('defaults @schemaRef props to type string without @schemaType', () => {
+    it('derives type string for a string-typed @schemaRef prop', () => {
       expect(result.components[0].props.properties.fileUri.type).toBe('string')
     })
 

--- a/test/component-index-props.test.ts
+++ b/test/component-index-props.test.ts
@@ -383,6 +383,20 @@ describe('Component Index - Prop Metadata Extraction', () => {
       expect(fileUriProp['x-allowed-schemes']).toEqual(['public'])
     })
 
+    it('honours @schemaType for an object $ref', () => {
+      const richImageProp = result.components[0].props.properties.richImage
+
+      // Canvas resolves storage from `type` before resolving `$ref`, so an
+      // object definition only matches when the prop declares type: object.
+      expect(richImageProp.type).toBe('object')
+      expect(richImageProp['$ref']).toBe('json-schema-definitions://lupus_image.module/image')
+      expect(richImageProp.title).toBe('Rich image')
+    })
+
+    it('defaults @schemaRef props to type string without @schemaType', () => {
+      expect(result.components[0].props.properties.fileUri.type).toBe('string')
+    })
+
     it('extracts @example for @schemaRef props', () => {
       const fileUriProp = result.components[0].props.properties.fileUri
       const imageUriProp = result.components[0].props.properties.imageUri


### PR DESCRIPTION
## Summary

`@schemaRef` hard-coded `type: 'string'` on the generated prop definition. Canvas resolves a prop's storage from its JSON Schema `type` **before** it resolves the `$ref`, so a `$ref` pointing at an *object* definition never matched — only URI-ish string definitions were reachable. The visible symptom is a **media picker silently degrading to a plain string field**.

The prop's TypeScript declaration already states whether it is an object, and TypeScript is a hard prerequisite of the whole extraction, so the JSON Schema `type` is **derived from the resolved type** rather than restated in JSDoc:

```vue
/**
 * Image
 * @schemaRef lupus_image/image
 */
media?: LupusImage   // -> type: object
```

Nothing about existing `@schemaRef` props changes — string-typed props still map to `type: string`.

This unblocks Drupal extensions shipping their own `schema.json` definitions — the `json-schema-definitions://<extension>.module/<name>` stream wrapper reads a `schema.json` from *any* extension root, not only Canvas. MCD-1297 uses it for a richer image object (media copyright / caption / source / focal point) than Canvas' built-in `canvas.module/image`.

## Why the checker needed `schema: true`

`createChecker()` was constructed without the `schema` option, which **disables type resolution entirely** — every `prop.schema` came back as a bare type string, so a named interface (`LupusCanvasImage`) was indistinguishable from a string. Deriving the type is only possible with resolution on.

Two things make that cheap and safe:

- vue-component-meta exposes a resolved schema's members through **lazy getters**, so enabling it costs one level of kind determination per prop, not a tree walk.
- The generated playground index is **byte-identical before and after apart from the one object-typed `$ref` prop** (verified by diffing the full generated index both ways). In particular the array-prop handling — which already had a structured-schema branch that had never been reachable — produces exactly the same output.

## Changes

- `deriveSchemaRefType()` reads the JSON Schema type off the prop's resolved schema: `kind: 'object'` → `object`; an optional prop (`kind: 'enum'` over `undefined | T`) with an object member → `object`; otherwise the usual type-string mapping.
- `createChecker(…, { schema: true })` so prop types resolve at all.
- Playground fixture prop `TestSchemaRefFile.richImage`, typed as a **named interface** to mirror real usage.
- Tests: an object-typed `$ref` prop derives `type: object`; a string-typed one derives `type: string`.
- README: the object-`$ref` paragraph documents derivation.

## Testing

`npm test` — **130/130 pass**. `npm run lint` — 0 errors (5 pre-existing warnings in an untouched file). Both re-run after merging `1.x` (nuxt 4.5.1 / vitest 4).

Refs: MCD-1297

_Drafted with Claude Code from claude-vm-1._
