### PR TITLE
fix: includePackages fails with vue-component-meta 3.3 and update it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "vue-component-meta": "^3.2.6"
+        "vue-component-meta": "^3.3.9"
       },
       "devDependencies": {
         "@nuxt/devtools": "^2.5.0",
@@ -6018,6 +6018,7 @@
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
       "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -6186,9 +6187,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.0.tgz",
-      "integrity": "sha512-5J9+NpCLHgic4xnZtI8SznvNagwJsZSvRFsAwoLlLw+Edaqa4upCiOC19P8Vx2DqmEvqK2qJBMtI8+9eXOEb/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
@@ -15505,13 +15506,13 @@
       }
     },
     "node_modules/vue-component-meta": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.2.9.tgz",
-      "integrity": "sha512-18FIQDctfCwpuTrMmAZJXR7fM48wrXNVcWrrhKgvARz2Sr8i1gIQ7gZdUaQwC9hfTxa9S0wIauPSf1et2xp0vQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue-component-meta/-/vue-component-meta-3.3.9.tgz",
+      "integrity": "sha512-4u1VmMVjqs9BbKaISBZD7b+dNdqFteh5BYN8xVaXkjjJ66no1sRtDnS6aSs5/P5AzQQGPw10snHTf/z3HpBn2w==",
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.2.9",
+        "@vue/language-core": "3.3.9",
         "path-browserify": "^1.0.1"
       },
       "peerDependencies": {
@@ -15521,6 +15522,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-component-meta/node_modules/@vue/language-core": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/vue-component-type-helpers": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
-    "vue-component-meta": "^3.2.6"
+    "vue-component-meta": "^3.3.9"
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.5.0",

--- a/src/runtime/server/utils/generateComponentIndex.ts
+++ b/src/runtime/server/utils/generateComponentIndex.ts
@@ -895,6 +895,27 @@ export interface ComponentIndexData {
   components: ComponentDefinition[]
 }
 
+/**
+ * Read a component's metadata, registering the file with the checker if it
+ * lies outside the tsconfig project.
+ *
+ * Components pulled in via `includePackages` live in node_modules, which the
+ * project tsconfig does not cover, and vue-component-meta only reads files
+ * that belong to the project or were added explicitly.
+ */
+function getComponentMeta(checker: ReturnType<typeof createChecker>, filePath: string) {
+  try {
+    return checker.getComponentMeta(filePath)
+  }
+  catch (error) {
+    if (!(error instanceof Error) || !error.message.includes('is not part of the project')) {
+      throw error
+    }
+    checker.updateFile(filePath, readFileSync(filePath, 'utf8'))
+    return checker.getComponentMeta(filePath)
+  }
+}
+
 export function generateComponentIndex(
   components: Component[],
   tsconfigPath: string,
@@ -970,7 +991,7 @@ export function generateComponentIndex(
 
   const componentData = filtered.map((component) => {
     try {
-      const meta = checker.getComponentMeta(component.filePath)
+      const meta = getComponentMeta(checker, component.filePath)
 
       // Extract props, filtering out Vue internals
       const vueInternalProps = ['key', 'ref', 'ref_for', 'ref_key', 'class', 'style']


### PR DESCRIPTION
Upgrades `vue-component-meta` 3.2.9 → 3.3.9, and fixes the behaviour change it introduces.

## The breakage
vue-component-meta 3.3 only reads files that belong to the tsconfig project or were registered explicitly. Components pulled in via **`includePackages`** live in `node_modules`, which the project tsconfig does not cover — so they silently dropped out of the component index:

```
Error processing component …/node_modules/@acme/ui-kit/AcmeButton.vue:
  '…' is not part of the project. Use a tsconfig that includes it, or call `updateFile()` to add it.
```

This is a real regression for consumers using `includePackages`, not just a test failure — the affected components disappear from `component-index.json`.

## The fix
`generateComponentIndex` now registers such a file with the checker (`updateFile`) and retries, so package components keep being indexed. Unrelated errors still propagate.

## Verification
Run locally on this branch:
- unit: **128/128 pass** (incl. the two `includePackages` cases that fail without the fix)
- e2e: **24/24 pass** (dev + production servers, real browser)
- lint: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135TzeJ5xX7vdwouF9Qd6yv