### PR TITLE
improve: Group renovate updates to reduce bot PR flood.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:recommended",
+    "group:allNonMajor",
+    "schedule:monthly",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 3,
+  "packageRules": [
+    {
+      "description": "All major updates in one grouped PR",
+      "matchUpdateTypes": ["major"],
+      "groupName": "major updates"
+    },
+    {
+      "description": "Security updates stay separate, bypass the schedule, high priority",
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "isVulnerabilityAlert": true,
+      "groupName": null,
+      "prPriority": 10,
+      "labels": ["security"],
+      "semanticCommitType": "fix"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  }
 }


### PR DESCRIPTION
## Current state

- **Renovate** (GitHub App) is active with a minimal `renovate.json` (`config:recommended` only) → one PR per dependency (`renovate/*` branches).
- **Dependabot**: there is **no** `.github/dependabot.yml` — all `dependabot/npm_and_yarn/*` PRs are GitHub **security-update** PRs (a repo-settings toggle, not repo config).
- Result: the queue recently held ~17 per-dependency bot PRs, cleared manually via #214.

## New bot behavior (this PR)

Renovate stays the single update bot (org standard, same app as kickstart):

- **One grouped PR for all non-major updates** (`group:allNonMajor`), **monthly** (`schedule:monthly`), semantic commit type `chore`, `rangeStrategy: bump`.
- **One grouped PR for all major updates** (custom `packageRules` group), same monthly schedule.
- **Security updates** stay separate per advisory, bypass the schedule, labeled `security`, commit type `fix`, high priority — mirrors the kickstart renovate config.
- `prConcurrentLimit: 3` as a hard cap.

Steady state: **at most 2 open bot PRs** (non-major group + major group), refreshed monthly, plus rare security PRs.

Config validated with `renovate-config-validator` (passes).

## Repo-settings action needed (admin only)

Dependabot security PRs are not controlled by any config file. To stop the duplicate `dependabot/*` security PRs, disable **Settings → Advanced Security → Dependabot security updates** (Renovate's `vulnerabilityAlerts` now covers this role). Leave *Dependabot alerts* on if desired — alerts without PRs are fine and feed Renovate's vulnerability detection.

## Open bot PRs to close once this lands

Renovate will close/supersede its own once the config is on `1.x`; the dependabot ones need manual closing (or disappear after the settings toggle + deps being current via #214):

- #217, #216, #186, #41 (renovate)
- #204, #200, #198, #197, #194, #187, #185, #184 (dependabot security)

(#191 is an unrelated external contribution — keep.)

---
Drafted with Claude Code from the loki dev VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)