### PR TITLE
fix: CSR-173 Portable defineNuxtPlugin imports; cover the module build with a test.

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,4 +1,8 @@
-import { defineNuxtPlugin, useState, useRuntimeConfig, onNuxtReady, nextTick } from '#imports'
+// `defineNuxtPlugin` comes from the portable `nuxt/app` subpath: with the
+// `#imports` alias the d.ts generator can only name the inferred
+// default-export type via a `node_modules` path (TS2742).
+import { defineNuxtPlugin } from 'nuxt/app'
+import { useState, useRuntimeConfig, onNuxtReady, nextTick } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   // Only activate when preview mode is enabled. Primary flag is

--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -1,6 +1,4 @@
-// `defineNuxtPlugin` comes from the portable `nuxt/app` subpath: with the
-// `#imports` alias the d.ts generator can only name the inferred
-// default-export type via a `node_modules` path (TS2742).
+// Portable `nuxt/app` import — via `#imports` the generated d.ts cannot name the export type (TS2742).
 import { defineNuxtPlugin } from 'nuxt/app'
 import { useState, useRuntimeConfig, onNuxtReady, nextTick } from '#imports'
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,6 +1,4 @@
-// `defineNuxtPlugin` comes from the portable `nuxt/app` subpath: with the
-// `#imports` alias the d.ts generator can only name the inferred
-// default-export type via a `node_modules` path (TS2742).
+// Portable `nuxt/app` import — via `#imports` the generated d.ts cannot name the export type (TS2742).
 import { defineNuxtPlugin } from 'nuxt/app'
 import { useRuntimeConfig } from '#imports'
 

--- a/src/runtime/plugins/cdn-fetch-paths.client.ts
+++ b/src/runtime/plugins/cdn-fetch-paths.client.ts
@@ -1,4 +1,8 @@
-import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
+// `defineNuxtPlugin` comes from the portable `nuxt/app` subpath: with the
+// `#imports` alias the d.ts generator can only name the inferred
+// default-export type via a `node_modules` path (TS2742).
+import { defineNuxtPlugin } from 'nuxt/app'
+import { useRuntimeConfig } from '#imports'
 
 /**
  * `$fetch` / `$fetch.native` override for component previews.

--- a/test/module-build.test.ts
+++ b/test/module-build.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Runs the real `nuxt-module-build build` and fails on any build warning.
+ *
+ * The builder exits non-zero on warnings (`failOnWarn`), which covers
+ * d.ts-generation problems such as TS2742 ("inferred type cannot be named
+ * without a reference to node_modules/…") that only surface at pack time —
+ * CI otherwise never executes the module build.
+ */
+// @vitest-environment node
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { describe, it, expect } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const rootDir = join(fileURLToPath(import.meta.url), '../..')
+
+describe('module build', () => {
+  it('builds without warnings or type errors', { timeout: 240_000 }, async () => {
+    let stdout: string
+    let stderr: string
+    let exitCode = 0
+    try {
+      ({ stdout, stderr } = await execFileAsync(
+        join(rootDir, 'node_modules/.bin/nuxt-module-build'),
+        ['build'],
+        { cwd: rootDir, maxBuffer: 10 * 1024 * 1024 },
+      ))
+    }
+    catch (error) {
+      const e = error as { code?: number, stdout?: string, stderr?: string }
+      exitCode = e.code ?? 1
+      stdout = e.stdout ?? ''
+      stderr = e.stderr ?? ''
+    }
+
+    const output = `${stdout}\n${stderr}`
+    expect(output).not.toMatch(/error TS\d+/)
+    expect(output).not.toContain('mkdist build failed')
+    expect(exitCode, `nuxt-module-build exited with ${exitCode}:\n${output}`).toBe(0)
+  })
+})


### PR DESCRIPTION
Fixes the `nuxt-module-build build` failure that blocks the 1.1.0 release ([CSR-173](https://drunomics.youtrack.cloud/issue/CSR-173)):

```
src/runtime/plugin.client.ts(3,1): error TS2742: The inferred type of 'default' cannot be named
without a reference to '~/node_modules/nuxt/dist/app/nuxt'. This is likely not portable.
src/runtime/plugins/cdn-fetch-paths.client.ts(33,1): error TS2742 (same)
```

## Fix

Import `defineNuxtPlugin` from the portable `nuxt/app` subpath instead of the `#imports` alias in both runtime plugins. With the alias, the d.ts generator can only name the inferred default-export type through a `node_modules` path; via `nuxt/app` the type is nameable with a proper module specifier. All other auto-imports stay on `#imports`. Surfaced by the dependency bumps (nuxt 4.5, TS ~5.9, vue-tsc 3).

## Test coverage

CI runs lint + vitest + e2e but never the module build, so pack-time d.ts failures were invisible until release. New `test/module-build.test.ts` executes the real `nuxt-module-build build` and asserts exit 0, no `error TS*`, no `mkdist build failed` — the builder's `failOnWarn` makes warnings fail the test too.

## Verification

- `npx vitest run test/module-build.test.ts` → green with the fix (build clean, ~7 s).
- Negative test: with both import fixes reverted, the test fails with exactly the two TS2742 errors. (Note: reverting only *one* file still passes — once any file in the program imports `nuxt/app`, TS can name the type portably program-wide — so the guard needs the test, not just one clean file.)
- `test/cdn-fetch-paths.test.ts` (16 tests) green; lint: 0 errors (5 pre-existing warnings untouched).

Drafted with assistance from Claude Code in the loki dev VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192LX8MPzDkawiq59dB2yMu