### PR TITLE
fix: MCD-1295 Declare minimatch as a runtime dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nuxt-component-preview",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-component-preview",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "minimatch": "^10.0.3",
         "vue-component-meta": "^3.3.9"
       },
       "devDependencies": {
@@ -22,7 +23,6 @@
         "@vue/test-utils": "^2.4.6",
         "eslint": "^10.0.0",
         "happy-dom": "^20.0.11",
-        "minimatch": "^10.0.3",
         "nuxt": "^4.5.1",
         "nuxtjs-drupal-ce": "^2.5.0-rc.2",
         "playwright-core": "^1.48.0",
@@ -5521,7 +5521,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5677,7 +5676,6 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -9413,7 +9411,6 @@
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.8"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
+    "minimatch": "^10.0.3",
     "vue-component-meta": "^3.3.9"
   },
   "devDependencies": {
@@ -48,7 +49,6 @@
     "@vue/test-utils": "^2.4.6",
     "eslint": "^10.0.0",
     "happy-dom": "^20.0.11",
-    "minimatch": "^10.0.3",
     "nuxt": "^4.5.1",
     "nuxtjs-drupal-ce": "^2.5.0-rc.2",
     "playwright-core": "^1.48.0",


### PR DESCRIPTION
`minimatch` is imported at runtime in `src/runtime/server/utils/generateComponentIndex.ts` (bundled into `dist/module.mjs`, executed during `nuxt prepare`), but was only declared in `devDependencies`. Consumers therefore resolve whatever `minimatch` happens to be hoisted to their top-level `node_modules/` — a phantom dependency.

When the hoisted copy is minimatch ≤5 (CJS-only, no named export), `nuxt prepare` fails with:

```
[error] Named export 'minimatch' not found. The requested module 'minimatch' is a
CommonJS module, which may not support all module.exports as named exports.
  at async Array.<anonymous> (node_modules/nuxt-component-preview/dist/module.mjs:141:44)
```

Moving `minimatch` from `devDependencies` to `dependencies` guarantees an ESM-capable ≥10 copy resolves for the module's import.

---
Drafted with Claude Code.