### PR TITLE
fix: component index cache header are not applied in production builds

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -39,6 +39,19 @@ export interface ModuleOptions {
   cdnFetchPaths?: string[]
 }
 
+const COMPONENT_INDEX_ROUTE = '/nuxt-component-preview/component-index.json'
+
+/**
+ * Cache-Control for the component index.
+ *
+ * The index lives at a stable URL but its body changes with every deploy, and
+ * consumers derive persisted state from it (Drupal Canvas registers component
+ * prop shapes from this file), so a stale copy is not a cosmetic problem.
+ * A short shared TTL keeps it cacheable while bounding staleness to a minute;
+ * the ETag on the response makes the revalidation after that a 304.
+ */
+const COMPONENT_INDEX_CACHE_CONTROL = 'public, max-age=60, must-revalidate'
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-component-preview',
@@ -255,13 +268,27 @@ export default defineNuxtModule<ModuleOptions>({
         nitroConfig.virtual['#nuxt-component-preview-config-path'] = () => {
           return `export default ${JSON.stringify(configPath)}`
         }
+
+        // A route rule rather than a header set in the handler: it is the only
+        // form that holds in every output mode. In SSR production the index is
+        // a static file served by Nitro's public-asset handler, which sets no
+        // Cache-Control of its own and never runs our handler; for SSG,
+        // deployment presets translate route rules into their own header
+        // config (netlify `_headers`, cloudflare `_headers`, …). Spread last so
+        // an explicit rule in the consuming app still wins.
+        nitroConfig.routeRules = {
+          [COMPONENT_INDEX_ROUTE]: {
+            headers: { 'cache-control': COMPONENT_INDEX_CACHE_CONTROL },
+          },
+          ...nitroConfig.routeRules,
+        }
       })
 
       if (nuxt.options.dev || nuxt.options._generate) {
         // Dev: handler for live generation on each request.
         // SSG (nuxt generate): handler needed for prerendering.
         addServerHandler({
-          route: '/nuxt-component-preview/component-index.json',
+          route: COMPONENT_INDEX_ROUTE,
           handler: resolver.resolve('./runtime/server/routes/nuxt-component-preview/component-index.json.get'),
         })
 
@@ -269,7 +296,7 @@ export default defineNuxtModule<ModuleOptions>({
           nuxt.hook('nitro:config', (nitroConfig) => {
             nitroConfig.prerender = nitroConfig.prerender || {}
             nitroConfig.prerender.routes = nitroConfig.prerender.routes || []
-            nitroConfig.prerender.routes.push('/nuxt-component-preview/component-index.json')
+            nitroConfig.prerender.routes.push(COMPONENT_INDEX_ROUTE)
           })
         }
       }

--- a/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
+++ b/src/runtime/server/routes/nuxt-component-preview/component-index.json.get.ts
@@ -27,8 +27,9 @@ export default defineEventHandler(async (event) => {
   }
 
   setHeader(event, 'Content-Type', 'application/json')
-  // Allow client cache but must revalidate, no proxy caching
-  setHeader(event, 'Cache-Control', 'private, must-revalidate, max-age=0')
+
+  // Cache-Control comes from the module's Nitro route rule, so that dev, SSG
+  // and SSR production all state the same policy for this URL.
 
   return componentIndexData
 })

--- a/test/component-index-route-rule.test.ts
+++ b/test/component-index-route-rule.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { execa } from 'execa'
+
+/**
+ * The index carries its Cache-Control as a Nitro route rule rather than a
+ * header set in the request handler, because the handler does not run in every
+ * output mode. Deployment presets consume route rules to write their own
+ * header config, so building against one of them (netlify here) is what proves
+ * the policy survives a static deployment.
+ */
+describe('component-index route rule (netlify preset)', () => {
+  const playgroundDir = join(fileURLToPath(import.meta.url), '../../playground')
+  const headersPath = join(playgroundDir, 'dist/_headers')
+  let headers: string
+
+  beforeAll(async () => {
+    await execa('npx', ['nuxi', 'build'], {
+      cwd: playgroundDir,
+      timeout: 180000,
+      env: {
+        ...process.env,
+        NITRO_PRESET: 'netlify',
+      },
+    })
+    headers = readFileSync(headersPath, 'utf-8')
+  }, 180000)
+
+  it('writes the component-index cache-control into the preset header config', () => {
+    expect(headers).toContain('/nuxt-component-preview/component-index.json\n  cache-control: public, max-age=60, must-revalidate')
+  })
+})

--- a/test/e2e/component-index-cache-control.test.ts
+++ b/test/e2e/component-index-cache-control.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { setup, fetch } from '@nuxt/test-utils/e2e'
+
+/**
+ * In SSR production the component index is a static file served by Nitro's
+ * public-asset handler, which sets no Cache-Control of its own. Left
+ * unlabelled, a CDN in front of the app is free to apply its own default TTL
+ * and serve an index from before the last deploy.
+ */
+describe('component-index cache-control (production SSR)', async () => {
+  await setup({
+    rootDir: join(fileURLToPath(import.meta.url), '../../../playground'),
+    server: true,
+    dev: false,
+  })
+
+  it('serves the index with a revalidating, shared-cacheable policy', async () => {
+    const res = await fetch('/nuxt-component-preview/component-index.json')
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60, must-revalidate')
+  })
+
+  it('serves an ETag so the revalidation can answer 304', async () => {
+    const res = await fetch('/nuxt-component-preview/component-index.json')
+    const etag = res.headers.get('etag')
+
+    expect(etag).toBeTruthy()
+
+    const revalidated = await fetch('/nuxt-component-preview/component-index.json', {
+      headers: { 'if-none-match': etag! },
+    })
+
+    expect(revalidated.status).toBe(304)
+  })
+})


### PR DESCRIPTION
## Problem

`/nuxt-component-preview/component-index.json` is a **stable URL whose body changes on every deploy**, and consumers derive *persisted state* from it — Drupal Canvas registers each component's prop expressions from this file and then walks stored component instances onto those versions. A stale read is therefore not a cosmetic staleness; it writes wrong prop shapes into stored config.

The module only ever set a `Cache-Control` on the code path that does **not** run in production:

- `component-index.json.get.ts` sets `private, must-revalidate, max-age=0`
- that handler is registered only when `nuxt.options.dev || nuxt.options._generate` (`src/module.ts`)
- in SSR production the `else` branch writes the index as a **static file** into Nitro's public dir — no handler, so that header never runs

Nitro's static handler (`nitropack/dist/runtime/internal/static.mjs`) sets `Content-Type`, `ETag`, `Last-Modified`, `Content-Encoding` and `Content-Length` — and never `Cache-Control`. So **the origin sends no `Cache-Control` at all** for this file in production, leaving any CDN in front of the app free to apply its own default TTL. On our BunnyCDN pull zones that default is 30 days, measured across every production mossbo site.

## Fix

Declare the policy as a **Nitro route rule** instead of a header set in the handler:

```ts
nitroConfig.routeRules = {
  '/nuxt-component-preview/component-index.json': {
    headers: { 'cache-control': 'public, max-age=60, must-revalidate' },
  },
  ...nitroConfig.routeRules,
}
```

A route rule is the only form that holds in **all three** output modes:

| mode | why it works |
| --- | --- |
| SSR production (static file) | `createRouteRulesHandler` is registered on the h3 app *before* every other handler (`nitropack/.../app.mjs`), so headers are already set when the static handler runs — and that handler only fills in headers it doesn't find |
| dev / SSG prerender | route rules apply to the handler response too, so all modes now state one policy |
| **static deployment** | deployment presets translate route rules into their own header config — the netlify preset's `writeHeaders()` emits `_headers`, likewise cloudflare |

The handler's own `setHeader` is dropped so there is a single source of truth. The rule is spread *last* so an explicit rule in the consuming app still wins.

`public, max-age=60, must-revalidate` keeps the file shared-cacheable while bounding staleness to a minute; the `ETag` the static handler already emits makes the revalidation after that a 304.

## Verified

Netlify-preset build of the playground now emits:

```
$ NITRO_PRESET=netlify npx nuxi build playground && cat playground/dist/_headers
/nuxt-component-preview/component-index.json
  cache-control: public, max-age=60, must-revalidate
/_nuxt/*
  cache-control: public, max-age=31536000, immutable
```

## Test coverage

- `test/component-index-route-rule.test.ts` — builds the playground with `NITRO_PRESET=netlify` and asserts the rule lands in the emitted `_headers`. Covers the SSG/adapter requirement. Confirmed to **fail** with the fix reverted.
- `test/e2e/component-index-cache-control.test.ts` — boots the real production SSR server and asserts the served `cache-control`, plus that an `If-None-Match` revalidation answers `304`. Covers the mode that was actually broken.

Locally: `npm test` → 9 files / 132 tests passing; `npx eslint` clean on the changed files. The pre-existing browser-based e2e specs could not run in this VM (no playwright browser binaries installed) — unrelated to this change.

---
Drafted with Claude Code.

